### PR TITLE
Performance Analyses for DPDK Applications Using the Ethdev Library

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/META-INF/MANIFEST.MF
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/META-INF/MANIFEST.MF
@@ -15,8 +15,13 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.tracecompass.tmf.core,
  org.eclipse.tracecompass.tmf.ctf.core,
  org.eclipse.tracecompass.analysis.os.linux.core,
- org.eclipse.jdt.annotation;bundle-version="2.2.400"
+ org.eclipse.jdt.annotation;bundle-version="2.2.400",
+ org.eclipse.tracecompass.analysis.lami.core,
+ com.google.guava
 Export-Package: org.eclipse.tracecompass.incubator.dpdk.core.trace,
+ org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis,
+ org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis,
+ org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis,
  org.eclipse.tracecompass.incubator.internal.dpdk.core.lcore.analysis;x-friends:="org.eclipse.tracecompass.incubator.dpdk.core.tests"
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.dpdk.core
 Import-Package: com.google.common.collect,

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
@@ -22,6 +22,16 @@
                class="org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace">
          </tracetype>
       </module>
+      <module
+            analysis_module="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.DpdkEthdevAnalysisModule"
+            automatic="true"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.analysis"
+            name="DPDK Ethernet Throughput Analysis">
+         <tracetype
+               applies="true"
+               class="org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace">
+         </tracetype>
+      </module>
    </extension>
    <extension
          point="org.eclipse.tracecompass.tmf.core.dataprovider">
@@ -32,6 +42,14 @@
       <dataProviderFactory
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEtherRateDataProviderFactory"
             id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.dataprovider">
+      </dataProviderFactory>
+      <dataProviderFactory
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.DpdkEtherThroughputBpsDataProviderFactory"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.bps.dataprovider">
+      </dataProviderFactory>
+      <dataProviderFactory
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.DpdkEtherThroughputPpsDataProviderFactory"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.pps.dataprovider">
       </dataProviderFactory>
    </extension>
    <extension

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
@@ -66,6 +66,13 @@
       </dataProviderFactory>
    </extension>
    <extension
+         point="org.eclipse.tracecompass.tmf.core.analysis.ondemand">
+      <analysis
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis.PollDistributionAnalysis"
+            id="org.eclipse.tracecompass.incubator.dpdk.core.ethdev.poll.distribution">
+      </analysis>
+   </extension>
+   <extension
          point="org.eclipse.linuxtools.tmf.core.tracetype">
       <type
             category="org.eclipse.linuxtools.tmf.ctf.core.category.ctf"

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
@@ -12,12 +12,26 @@
                class="org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace">
          </tracetype>
       </module>
+            <module
+            analysis_module="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEthdevRateAnalysis"
+            automatic="true"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.analysis"
+            name="DPDK Ethernet Rate Analysis">
+         <tracetype
+               applies="true"
+               class="org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace">
+         </tracetype>
+      </module>
    </extension>
    <extension
          point="org.eclipse.tracecompass.tmf.core.dataprovider">
       <dataProviderFactory
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.lcore.analysis.DpdkLogicalCoreDataProviderFactory"
             id="org.eclipse.tracecompass.incubator.dpdk.lcore.dataprovider">
+      </dataProviderFactory>
+      <dataProviderFactory
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEtherRateDataProviderFactory"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.dataprovider">
       </dataProviderFactory>
    </extension>
    <extension

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
@@ -23,6 +23,15 @@
          </tracetype>
       </module>
       <module
+            analysis_module="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis.DpdkEthdevSpinAnalysisModule"
+            id="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis"
+            name="DPDK Ethernet Spin Analysis">
+         <tracetype
+               applies="true"
+               class="org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace">
+         </tracetype>
+      </module>
+      <module
             analysis_module="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.DpdkEthdevAnalysisModule"
             automatic="true"
             id="org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.analysis"
@@ -42,6 +51,10 @@
       <dataProviderFactory
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEtherRateDataProviderFactory"
             id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.dataprovider">
+      </dataProviderFactory>
+      <dataProviderFactory
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis.DpdkEtherSpinDataProviderFactory"
+            id="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.dataprovider">
       </dataProviderFactory>
       <dataProviderFactory
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.DpdkEtherThroughputBpsDataProviderFactory"

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
@@ -68,6 +68,10 @@
    <extension
          point="org.eclipse.tracecompass.tmf.core.analysis.ondemand">
       <analysis
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.stats.analysis.PollStatsAnalysis"
+            id="org.eclipse.tracecompass.incubator.dpdk.core.ethdev.poll.stats">
+      </analysis>
+      <analysis
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis.PollDistributionAnalysis"
             id="org.eclipse.tracecompass.incubator.dpdk.core.ethdev.poll.distribution">
       </analysis>

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/DpdkEthdevEventLayout.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/DpdkEthdevEventLayout.java
@@ -1,0 +1,74 @@
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis;
+
+
+/**
+ * The event layout class to specify event names and their fields
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevEventLayout {
+
+    /* Event names */
+    private static final String ETH_DEV_RXQ_BURST_NON_EMPTY = "lib.ethdev.rx.burst.nonempty"; //$NON-NLS-1$
+
+    /* Event field names */
+    private static final String PORT_ID = "port_id"; //$NON-NLS-1$
+    private static final String QUEUE_ID = "queue_id"; //$NON-NLS-1$
+    private static final String NB_RX = "nb_rx"; //$NON-NLS-1$
+    private static final String THREAD_NAME = "context.name";  //$NON-NLS-1$
+    private static final String CPU_ID = "context.cpu_id";  //$NON-NLS-1$
+
+
+    // ------------------------------------------------------------------------
+    // Event names
+    // ------------------------------------------------------------------------
+
+    /**
+     * This event is generated when a burst of packets is received
+     *
+     * @return The event name
+     */
+    public static String eventEthdevRxqBurstNonEmpty() {
+        return ETH_DEV_RXQ_BURST_NON_EMPTY;
+    }
+
+    // ------------------------------------------------------------------------
+    // Event field names
+    // ------------------------------------------------------------------------
+
+    /**
+     * @return Number identifying a NIC port
+     */
+    public static String fieldPortId() {
+        return PORT_ID;
+    }
+
+    /**
+     * @return Number identifying a queue that is associated to a NIC port
+     */
+    public static String fieldQueueId() {
+        return QUEUE_ID;
+    }
+
+    /**
+     * @return The number of packets received
+     */
+    public static String fieldNbRxPkts() {
+        return NB_RX;
+    }
+
+    /**
+     * @return The name of the thread issuing the DPDK event
+     */
+    public static String fieldThreadName() {
+        return THREAD_NAME;
+    }
+
+    /**
+     * @return The identifier of the CPU on which the DPDK event was recorded
+     */
+    public static String fieldCpuId() {
+        return CPU_ID;
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/Messages.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for the {@link PollDistributionAnalysis} on-demand analysis
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings("javadoc")
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis.messages"; //$NON-NLS-1$
+
+    public static @Nullable String AspectName_PortQueueName;
+    public static @Nullable String AspectName_FieldPortName;
+    public static @Nullable String AspectHelpText_PortQueueName;
+
+    static @NonNull String getMessage(@Nullable String msg) {
+        if (msg == null) {
+            return ""; //$NON-NLS-1$
+        }
+        return msg;
+    }
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/PollDistributionAnalysis.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/PollDistributionAnalysis.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.aspect.LamiGenericAspect;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.aspect.LamiTableEntryAspect;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiAnalysis;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiResultTable;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiTableClass;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiTableEntry;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiData;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiLongNumber;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiTimeRange;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiTimestamp;
+import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+import org.eclipse.tracecompass.tmf.core.event.aspect.TmfContentFieldAspect;
+import org.eclipse.tracecompass.tmf.core.filter.model.TmfFilterMatchesNode;
+import org.eclipse.tracecompass.tmf.core.request.ITmfEventRequest.ExecutionType;
+import org.eclipse.tracecompass.tmf.core.request.TmfEventRequest;
+import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+/**
+ * Dpdk polls distribution analysis is an on-demand analysis that calculates the
+ * number of packets retrieved in a single call to rte_eth_rx_burst(). The poll
+ * distribution is calculated per port queue only.
+ *
+ * @author Adel Belkhiri
+ *
+ */
+public class PollDistributionAnalysis extends LamiAnalysis {
+
+    private static final long MASK = (1 << 10) - 1L;
+    private static final int MEMORY_SANITY_LIMIT = 40000;
+
+    /**
+     * Constructor
+     */
+    @SuppressWarnings("restriction")
+    public PollDistributionAnalysis() {
+        super("DPDK Polls Distribution (ethdev)", false, trace -> true, Collections.emptyList()); //$NON-NLS-1$
+    }
+
+    @Override
+    protected synchronized void initialize() {
+        // do nothing
+    }
+
+    @Override
+    public boolean canExecute(ITmfTrace trace) {
+        if (trace instanceof DpdkTrace) {
+            return ((DpdkTrace) trace).validate(null, trace.getPath()).isOK()? true : false;
+        }
+        return false;
+    }
+
+    private static int workRemaining(ITmfTrace trace) {
+        return (int) Math.min(trace.getNbEvents() / (MASK + 1), Integer.MAX_VALUE);
+    }
+
+    @SuppressWarnings("restriction")
+    @Override
+    public List<LamiResultTable> execute(ITmfTrace trace, @Nullable TmfTimeRange timeRange, String extraParamsString, IProgressMonitor monitor) throws CoreException {
+        List<LamiResultTable> results = new ArrayList<>();
+        TmfTimeRange tr = timeRange == null ? TmfTimeRange.ETERNITY : timeRange;
+
+        /* handle the filter in case the user set one */
+        TmfFilterMatchesNode filter = new TmfFilterMatchesNode(null);
+        filter.setEventAspect(new TmfContentFieldAspect(Messages.getMessage(Messages.AspectName_FieldPortName), DpdkEthdevEventLayout.fieldPortId()));
+        filter.setRegex(extraParamsString);
+
+        Predicate<ITmfEvent> filterPred = (event -> extraParamsString.isEmpty() || filter.matches(event));
+        SubMonitor mon = SubMonitor.convert(monitor, "Ethdev Polls Distribution", workRemaining(trace)); //$NON-NLS-1$
+        AtomicLong done = new AtomicLong();
+
+        // the poll aspect/count map
+        Map<String, Map<Integer, Long>> pollAspectCounts = new TreeMap<>();
+
+        /* create the event request */
+        TmfEventRequest req = new TmfEventRequest(ITmfEvent.class, tr, 0, Integer.MAX_VALUE, ExecutionType.BACKGROUND) {
+            @Override
+            public void handleData(ITmfEvent event) {
+                if (monitor.isCanceled()) {
+                    cancel();
+                }
+                if (event.getName().equals(DpdkEthdevEventLayout.eventEthdevRxqBurstNonEmpty()) && filterPred.test(event)) {
+                    TmfEtherPollAspect aspect = TmfEtherPollAspect.getInstance(event);
+                    Object resolved = aspect.resolve(event);
+                    if (resolved != null) {
+                        Map<Integer, Long> dataSet = pollAspectCounts.computeIfAbsent(aspect.getName(), unused -> new HashMap<>());
+                        if (dataSet.size() < MEMORY_SANITY_LIMIT) {
+                            int pollValue = (Integer) resolved;
+                            dataSet.put(pollValue, dataSet.getOrDefault(pollValue, 0L) + 1);
+                        }
+                    }
+                }
+                if ((done.incrementAndGet() & MASK) == 0) {
+                    mon.setWorkRemaining(workRemaining(trace));
+                    mon.worked(1);
+
+                    monitor.setTaskName("DPDK Polls Distribution Analysis (" + NumberFormat.getInstance().format(done.get()) + " events read)"); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            }
+
+        };
+        // send the request to the trace
+        trace.sendRequest(req);
+
+        // convert the result to Lami types
+        try {
+            req.waitForCompletion();
+            for (Entry<String, Map<Integer, Long>> entry : pollAspectCounts.entrySet()) {
+                List<LamiTableEntry> entries = new ArrayList<>();
+                Map<Integer, Long> dataSet = entry.getValue();
+                for (Entry<Integer, Long> element : dataSet.entrySet()) {
+                    List<LamiData> data = Arrays.asList(
+                            new LamiString(element.getKey().toString()),
+                            new LamiLongNumber(element.getValue()));
+
+                    entries.add(new LamiTableEntry(data));
+                }
+
+                List<LamiTableEntryAspect> tableAspects = Arrays.asList(new LamiCategoryAspect("Number of retrieved packets", 0), //$NON-NLS-1$
+                        new LamiCountAspect("Count", 1));
+                LamiTableClass tableClass = new LamiTableClass(entry.getKey(), entry.getKey(), tableAspects, Collections.emptySet());
+                LamiResultTable lrt = new LamiResultTable(createTimeRange(tr), tableClass, entries);
+                results.add(lrt);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return results;
+    }
+
+    /**
+     * Todo, move to LAMI
+     */
+    private static LamiTimeRange createTimeRange(TmfTimeRange timeRange) {
+        return new LamiTimeRange(new LamiTimestamp(timeRange.getStartTime().toNanos()), new LamiTimestamp(timeRange.getEndTime().toNanos()));
+    }
+
+    /**
+     * Todo, LamiString in LAMI is private
+     */
+    private final class LamiString extends LamiData {
+        private final String fElement;
+
+        private LamiString(String element) {
+            fElement = element;
+        }
+
+        @Override
+        public @NonNull String toString() {
+            return fElement;
+        }
+    }
+
+    /**
+     * Count aspect, generic
+     *
+     */
+    private final class LamiCountAspect extends LamiGenericAspect {
+        private LamiCountAspect(String name, int column) {
+            super(name, null, column, true, false);
+        }
+    }
+
+    /**
+     * Category aspect, generic
+     *
+     */
+    private final class LamiCategoryAspect extends LamiGenericAspect {
+        private LamiCategoryAspect(String name, int column) {
+            super(name, null, column, false, false);
+        }
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/TmfEtherPollAspect.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/TmfEtherPollAspect.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Alexandre Montplaisir - Initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
+
+/**
+ * Aspect representing a poll issued by a PMD thread for a specific Ethernet queue, at the timestamp of the
+ * event.
+ *
+ * @author Adel Belkhiri
+ */
+public class TmfEtherPollAspect implements ITmfEventAspect<Integer> {
+
+    private static final Map<String, TmfEtherPollAspect> instances = new HashMap<>();
+
+    private final String fName;
+
+    /**
+     * Constructor
+     *
+     * @param name
+     *      The name of this aspect, which is the name of the queue associated to the Ethernet port.
+     */
+    public TmfEtherPollAspect(String name) {
+        fName = name;
+    }
+
+    @Override
+    public String getName() {
+        return fName;
+    }
+
+    /**
+     * Factory method to create new instances
+     * @param event
+     *      ITmfEvent instance
+     * @return
+     *      An instance of an existing {@link TmfEtherPollAspect} or the newly created one
+     */
+    public static synchronized TmfEtherPollAspect getInstance(ITmfEvent event) {
+        Integer portId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldPortId());
+        Integer queueId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldQueueId());
+        String name = "P" + Objects.requireNonNull(portId).toString() + "/Q" + Objects.requireNonNull(queueId).toString();  //$NON-NLS-1$//$NON-NLS-2$
+
+        if (!instances.containsKey(name)) {
+            instances.put(name, new TmfEtherPollAspect(name));
+        }
+        return instances.get(name);
+    }
+
+    /**
+     * Gets all the aspects instances
+     * @return
+     *      A collection of {@link TmfEtherPollAspect}
+     */
+    public static Collection<TmfEtherPollAspect> getAllInstances() {
+        return instances.values();
+    }
+
+    @Override
+    public @NonNull String getHelpText() {
+        return Messages.getMessage(Messages.AspectHelpText_PortQueueName);
+    }
+
+    @Override
+    public @Nullable Integer resolve(ITmfEvent event) {
+        Integer nbRxPkts = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbRxPkts());
+        return Objects.requireNonNull(nbRxPkts);
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/distribution/analysis/messages.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2024 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+AspectName_PortQueueName=Port Queue
+AspectHelpText_PortQueueName=Queue polled through the call to rte_eth_rx_burst()
+AspectName_FieldPortName=Port ID

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/DpdkEthdevEventLayout.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/DpdkEthdevEventLayout.java
@@ -1,0 +1,74 @@
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.stats.analysis;
+
+
+/**
+ * The event layout class to specify event names and their fields
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevEventLayout {
+
+    /* Event names */
+    private static final String ETH_DEV_RXQ_BURST_NON_EMPTY = "lib.ethdev.rx.burst.nonempty"; //$NON-NLS-1$
+
+    /* Event field names */
+    private static final String PORT_ID = "port_id"; //$NON-NLS-1$
+    private static final String QUEUE_ID = "queue_id"; //$NON-NLS-1$
+    private static final String NB_RX = "nb_rx"; //$NON-NLS-1$
+    private static final String THREAD_NAME = "context.name";  //$NON-NLS-1$
+    private static final String CPU_ID = "context.cpu_id";  //$NON-NLS-1$
+
+
+    // ------------------------------------------------------------------------
+    // Event names
+    // ------------------------------------------------------------------------
+
+    /**
+     * This event is generated when a burst of packets is received
+     *
+     * @return The event name
+     */
+    public static String eventEthdevRxqBurstNonEmpty() {
+        return ETH_DEV_RXQ_BURST_NON_EMPTY;
+    }
+
+    // ------------------------------------------------------------------------
+    // Event field names
+    // ------------------------------------------------------------------------
+
+    /**
+     * @return Number identifying a NIC port
+     */
+    public static String fieldPortId() {
+        return PORT_ID;
+    }
+
+    /**
+     * @return Number identifying a queue that is associated to a NIC port
+     */
+    public static String fieldQueueId() {
+        return QUEUE_ID;
+    }
+
+    /**
+     * @return The number of packets received
+     */
+    public static String fieldNbRxPkts() {
+        return NB_RX;
+    }
+
+    /**
+     * @return The name of the thread issuing the DPDK event
+     */
+    public static String fieldThreadName() {
+        return THREAD_NAME;
+    }
+
+    /**
+     * @return The identifier of the CPU on which the DPDK event was recorded
+     */
+    public static String fieldCpuId() {
+        return CPU_ID;
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/Messages.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.stats.analysis;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for the {@link PollStatsAnalysis} on-demand analysis
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings("javadoc")
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.stats.analysis.messages"; //$NON-NLS-1$
+
+    public static @Nullable String AspectName_PortQueueName;
+    public static @Nullable String AspectHelpText_PortQueueName;
+    public static @Nullable String AspectName_ThreadName;
+    public static @Nullable String AspectHelpText_ThreadName;
+
+    static @NonNull String getMessage(@Nullable String msg) {
+        if (msg == null) {
+            return ""; //$NON-NLS-1$
+        }
+        return msg;
+    }
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/PollStatsAnalysis.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/PollStatsAnalysis.java
@@ -1,0 +1,290 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.stats.analysis;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.aspect.LamiGenericAspect;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.aspect.LamiTableEntryAspect;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiAnalysis;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiResultTable;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiTableClass;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.module.LamiTableEntry;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiData;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiDoubleNumber;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiLongNumber;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiTimeRange;
+import org.eclipse.tracecompass.internal.provisional.analysis.lami.core.types.LamiTimestamp;
+import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
+import org.eclipse.tracecompass.tmf.core.request.ITmfEventRequest.ExecutionType;
+import org.eclipse.tracecompass.tmf.core.request.TmfEventRequest;
+import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimeRange;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+/**
+ * The DPDK Polls Statistics Analysis is an on-demand analysis that computes
+ * statistics related to the polling of RX queues of Ethernet devices by PMD
+ * (Poll-Mode Driver) threads through calls to `rte_eth_rx_burst()`. The
+ * statistics include, per queue and per thread, the minimum, maximum, average,
+ * and standard deviation of the number of packets retrieved in a single call to
+ * the `rte_eth_rx_burst()` function.
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings("restriction")
+public class PollStatsAnalysis extends LamiAnalysis {
+
+    private static final long MASK = (1 << 10) - 1L;
+    private static final int MEMORY_SANITY_LIMIT = 40000;
+
+    /**
+     * Constructor
+     */
+    public PollStatsAnalysis() {
+        super("DPDK Polls Statistics (ethdev)", false, trace -> true, Collections.emptyList()); //$NON-NLS-1$
+    }
+
+    @Override
+    protected synchronized void initialize() {
+        // do nothing
+    }
+
+    @Override
+    public boolean canExecute(ITmfTrace trace) {
+        if (trace instanceof DpdkTrace) {
+            return ((DpdkTrace) trace).validate(null, trace.getPath()).isOK()? true : false;
+        }
+        return false;
+    }
+
+    private static int workRemaining(ITmfTrace trace) {
+        return (int) Math.min(trace.getNbEvents() / (MASK + 1), Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<LamiResultTable> execute(ITmfTrace trace, @Nullable TmfTimeRange timeRange, String extraParamsString, IProgressMonitor monitor) throws CoreException {
+        List<LamiResultTable> results = new ArrayList<>();
+        List<ITmfEventAspect<Pair<String, Integer>>> aspects = new ArrayList<>();
+        TmfTimeRange tr = timeRange == null ? TmfTimeRange.ETERNITY : timeRange;
+
+        /*
+         * the queue name and the thread name are required aspects for this
+         * analysis
+         */
+        aspects.add(PORT_QUEUE_NAME_ASPECT);
+        aspects.add(THREAD_NAME_ASPECT);
+
+        SubMonitor mon = SubMonitor.convert(monitor, "DPDK Polls Statistics Analysis", workRemaining(trace)); //$NON-NLS-1$
+        AtomicLong done = new AtomicLong();
+
+        // the event aspect/count map
+        Map<String, Map<String, List<Integer>>> pollAspectCounts = new HashMap<>();
+
+        /* create the event request */
+        TmfEventRequest req = new TmfEventRequest(ITmfEvent.class, tr, 0, Integer.MAX_VALUE, ExecutionType.BACKGROUND) {
+            @Override
+            public void handleData(ITmfEvent event) {
+                if (monitor.isCanceled()) {
+                    cancel();
+                }
+                if (event.getName().equals(DpdkEthdevEventLayout.eventEthdevRxqBurstNonEmpty())) {
+                    for (ITmfEventAspect<Pair<String, Integer>> aspect : aspects) {
+                        Pair<String, Integer> resolved = aspect.resolve(event);
+                        if (resolved != null) {
+                            Map<String, List<Integer>> dataSet = pollAspectCounts.computeIfAbsent(aspect.getName(), unused -> new HashMap<>());
+                            if (dataSet.size() < MEMORY_SANITY_LIMIT) {
+                                List<Integer> data = dataSet.computeIfAbsent(resolved.getFirst(), unused -> new ArrayList<>());
+                                data.add(resolved.getSecond());
+                            }
+                        }
+                    }
+                }
+                if ((done.incrementAndGet() & MASK) == 0) {
+                    mon.setWorkRemaining(workRemaining(trace));
+                    mon.worked(1);
+
+                    monitor.setTaskName("Dpdk Polls Statistics Analysis (" + NumberFormat.getInstance().format(done.get()) + " events read)"); //$NON-NLS-1$ //$NON-NLS-2$
+                }
+            }
+
+        };
+        // send the request to the trace
+        trace.sendRequest(req);
+
+        // convert the result to Lami types
+        try {
+            req.waitForCompletion();
+            for (Entry<String, Map<String, List<Integer>>> entry : pollAspectCounts.entrySet()) {
+
+                Map<String, List<Integer>> dataSet = entry.getValue();
+                List<LamiTableEntry> entries = new ArrayList<>();
+
+                for (Entry<String, List<Integer>> element : dataSet.entrySet()) {
+                    // Calculate the number of successful polls, along with the
+                    // min and max polls values
+                    int nbSuccessfulPolls = element.getValue().size();
+                    int minPollValue = Collections.min(element.getValue());
+                    int maxPollValue = Collections.max(element.getValue());
+
+                    // Calculate the mean and the standard deviation
+                    double avgPollValue = element.getValue().stream().mapToInt(i -> i).average().orElse(0);
+                    double sd = element.getValue().stream().mapToDouble(val -> Math.pow(val - avgPollValue, 2)).sum();
+                    double std = Math.sqrt(sd / element.getValue().size());
+
+                    BigDecimal bd = new BigDecimal(std).setScale(2, RoundingMode.HALF_UP);
+                    double rounded = bd.doubleValue();
+
+                    List<LamiData> data = Arrays.asList(
+                            new LamiString(element.getKey()),
+                            new LamiLongNumber((long) minPollValue),
+                            new LamiLongNumber((long) maxPollValue),
+                            new LamiLongNumber((long) avgPollValue),
+                            new LamiDoubleNumber(rounded),
+                            new LamiLongNumber((long) nbSuccessfulPolls));
+
+                    entries.add(new LamiTableEntry(data));
+                }
+
+                List<LamiTableEntryAspect> tableAspects = Arrays.asList(new LamiCategoryAspect(entry.getKey(), 0),
+                        new LamiCountAspect("Minimum Value", 1),
+                        new LamiCountAspect("Maximum Value", 2),
+                        new LamiCountAspect("Average Value", 3),
+                        new LamiCountAspect("Standard Deviation", 4),
+                        new LamiCountAspect("Count", 5));
+                LamiTableClass tableClass = new LamiTableClass(entry.getKey(), entry.getKey(), tableAspects, Collections.emptySet());
+                LamiResultTable lrt = new LamiResultTable(createTimeRange(tr), tableClass, entries);
+                results.add(lrt);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return results;
+    }
+
+    /**
+     * Todo, move to LAMI
+     */
+    private static LamiTimeRange createTimeRange(TmfTimeRange timeRange) {
+        return new LamiTimeRange(new LamiTimestamp(timeRange.getStartTime().toNanos()), new LamiTimestamp(timeRange.getEndTime().toNanos()));
+    }
+
+    /**
+     * Todo, move to LAMI
+     */
+    private final class LamiString extends LamiData {
+        private final String fElement;
+
+        private LamiString(String element) {
+            fElement = element;
+        }
+
+        @Override
+        public @NonNull String toString() {
+            return fElement;
+        }
+    }
+
+    /**
+     * Count aspect, generic
+     *
+     * TODO: move to LAMI
+     *
+     */
+    private final class LamiCountAspect extends LamiGenericAspect {
+
+        private LamiCountAspect(String name, int column) {
+            super(name, null, column, true, false);
+        }
+    }
+
+    /**
+     * Category aspect, generic
+     *
+     * TODO: move to LAMI
+     *
+     */
+    private final class LamiCategoryAspect extends LamiGenericAspect {
+
+        private LamiCategoryAspect(String name, int column) {
+            super(name, null, column, false, false);
+        }
+    }
+
+    /**
+     * Event aspect that resolves in the name of the queue targeted by the poll,
+     * and the number of packets retrieved in a single call to the
+     * rte_eth_rx_burst() function.
+     */
+    private static final ITmfEventAspect<Pair<String, Integer>> PORT_QUEUE_NAME_ASPECT = new ITmfEventAspect<Pair<String, Integer>>() {
+        @Override
+        public String getName() {
+            return Messages.getMessage(Messages.AspectName_PortQueueName);
+        }
+
+        @Override
+        public String getHelpText() {
+            return Messages.getMessage(Messages.AspectHelpText_PortQueueName);
+        }
+
+        @Override
+        public @Nullable Pair<String, Integer> resolve(ITmfEvent event) {
+            Integer portId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldPortId());
+            Integer queueId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldQueueId());
+            Integer nbRxPkts = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbRxPkts());
+            String queueName = "P" + Objects.requireNonNull(portId).toString() + "/Q" + Objects.requireNonNull(queueId).toString(); //$NON-NLS-1$//$NON-NLS-2$
+
+            return new Pair<>(queueName, Objects.requireNonNull(nbRxPkts));
+        }
+    };
+
+    /**
+     * Event aspect that resolves in the name of the thread issuing the current
+     * poll, along with the number of retrieved packets
+     */
+    private static final ITmfEventAspect<Pair<String, Integer>> THREAD_NAME_ASPECT = new ITmfEventAspect<Pair<String, Integer>>() {
+        @Override
+        public String getName() {
+            return Messages.getMessage(Messages.AspectName_ThreadName);
+        }
+
+        @Override
+        public String getHelpText() {
+            return Messages.getMessage(Messages.AspectHelpText_ThreadName);
+        }
+
+        @Override
+        public @Nullable Pair<String, Integer> resolve(ITmfEvent event) {
+            String threadName = event.getContent().getFieldValue(String.class, DpdkEthdevEventLayout.fieldThreadName());
+            Integer nbRxPkts = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbRxPkts());
+
+            return new Pair<>(threadName, Objects.requireNonNull(nbRxPkts));
+        }
+    };
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/poll/stats/analysis/messages.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2024 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+AspectName_PortQueueName=Port Queue
+AspectHelpText_PortQueueName=Queue targeted by the rte_eth_rx_burst event
+AspectName_ThreadName=PMD Thread
+AspectHelpText_ThreadName=The PMD thread 

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/Attributes.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/Attributes.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+/**
+ * This file defines all the attribute names used in the handler. Both the
+ * construction and query steps should use them.
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings({ "nls" })
+public interface Attributes {
+
+    /* First-level attributes */
+
+    /** Root attribute for DPDK Ethdev Nics */
+    String NICS = "NICs";
+    /** Reception Queues */
+    String RX_Q = "Rx_Q";
+    /** Transmission Queues */
+    String TX_Q = "Tx_Q";
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevEventHandler.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevEventHandler.java
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+import java.util.Objects;
+
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
+import org.eclipse.tracecompass.statesystem.core.StateSystemBuilderUtils;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateValueTypeException;
+import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+
+/**
+ * Event handler to handle DPDK ethdev library events
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevEventHandler implements IDpdkEventHandler {
+
+    /* Attribute names */
+    private static final String ETH_NICS = Objects.requireNonNull(Attributes.NICS);
+    private static final String RX_Q = Objects.requireNonNull(Attributes.RX_Q);
+    private static final String TX_Q = Objects.requireNonNull(Attributes.TX_Q);
+
+    DpdkEthdevEventHandler() {
+        // Nothing here
+    }
+
+    /**
+     * Create an Ethernet (RX or TX) queue on the state system
+     *
+     * @param ts
+     *            time to use for state change
+     */
+    static private void createNicQueue(ITmfStateSystemBuilder ssb, int queueSetQuark, int nbQueues, long ts) {
+        if (nbQueues <= 0) {
+            return;
+        }
+
+        for (int i = 0; i < nbQueues; i++) {
+            ssb.getQuarkRelativeAndAdd(queueSetQuark, String.valueOf(i));
+        }
+    }
+
+    /**
+     * Update the count of received or transmitted packets on the state system
+     *
+     * @param ssb
+     *            State System builder
+     * @param queueQuark
+     *            Quark of the the Ethernet device queue
+     * @param nbPkts
+     *            Number of packets received or transmitted
+     * @param ts
+     *            time to use for state change
+     */
+    public void updateCounts(ITmfStateSystemBuilder ssb, int queueQuark, Integer nbPkts, long ts) {
+        if (nbPkts <= 0) {
+            return;
+        }
+        try {
+            StateSystemBuilderUtils.incrementAttributeLong(ssb, ts, queueQuark, nbPkts);
+        } catch (StateValueTypeException e) {
+            Activator.getInstance().logWarning(getClass().getName() + ": problem accessing the state of a NIC queue (Quark =" + String.valueOf(queueQuark) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    @Override
+    public void handleEvent(ITmfStateSystemBuilder ssb, ITmfEvent event) {
+        Integer portId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldPortId());
+        long ts = event.getTimestamp().getValue();
+        String eventName = event.getName();
+
+        if (eventName.equals(DpdkEthdevEventLayout.eventEthdevConfigure())) {
+            Integer rc = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldRc());
+            Integer nbRxQueues = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbRxQ());
+            Integer nbTxQueues = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbTxQ());
+
+            if (Objects.requireNonNull(rc) == 0) {
+                // save the new Ethernet device on the satet system
+                int portQuark = ssb.getQuarkAbsoluteAndAdd(ETH_NICS, String.valueOf(portId));
+                int rxQueueQark = ssb.getQuarkRelativeAndAdd(portQuark, RX_Q);
+                createNicQueue(ssb, rxQueueQark, Objects.requireNonNull(nbRxQueues), ts);
+                int txQueueQark = ssb.getQuarkRelativeAndAdd(portQuark, TX_Q);
+                createNicQueue(ssb, txQueueQark, Objects.requireNonNull(nbTxQueues), ts);
+            } else {
+                Activator.getInstance().logWarning("The event " + DpdkEthdevEventLayout.eventEthdevConfigure() + " presents a Non-Null RC value"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+
+        } else if (eventName.equals(DpdkEthdevEventLayout.eventEthdevRxqBurstNonEmpty())) {
+            Integer queueId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldQueueId());
+            Integer nbRxPkts = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbRxPkts());
+            int portQuark = ssb.getQuarkAbsoluteAndAdd(ETH_NICS, String.valueOf(portId));
+            int rxQsQark = ssb.getQuarkRelativeAndAdd(portQuark, RX_Q);
+            int rxQueueQark = ssb.getQuarkRelativeAndAdd(rxQsQark, Objects.requireNonNull(queueId).toString());
+            updateCounts(ssb, rxQueueQark, Objects.requireNonNull(nbRxPkts), ts);
+
+        } else if (eventName.equals(DpdkEthdevEventLayout.eventEthdevTxqBurst())) {
+            Integer queueId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldQueueId());
+            Integer nbTxPkts = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbPkts());
+            int portQuark = ssb.getQuarkAbsoluteAndAdd(ETH_NICS, String.valueOf(portId));
+            int txQsQark = ssb.getQuarkRelativeAndAdd(portQuark, TX_Q);
+            int txQueueQark = ssb.getQuarkRelativeAndAdd(txQsQark, Objects.requireNonNull(queueId).toString());
+            updateCounts(ssb, txQueueQark, Objects.requireNonNull(nbTxPkts), ts);
+        }
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevEventLayout.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevEventLayout.java
@@ -1,0 +1,109 @@
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+
+/**
+ * The event layout class to specify event names and their fields
+ *
+ * @author Adel Belkhiri
+ * @author Arnaud Fiorini
+ */
+public class DpdkEthdevEventLayout {
+
+    /* Event names */
+    private static final String ETH_DEV_CONFIGURE = "lib.ethdev.configure"; //$NON-NLS-1$
+    private static final String ETH_DEV_RXQ_BURST_NON_EMPTY = "lib.ethdev.rx.burst.nonempty"; //$NON-NLS-1$
+    private static final String ETH_DEV_TXQ_BURST = "lib.ethdev.tx.burst"; //$NON-NLS-1$
+
+    /* Event field names */
+    private static final String PORT_ID = "port_id"; //$NON-NLS-1$
+    private static final String QUEUE_ID = "queue_id"; //$NON-NLS-1$
+    private static final String NB_RX_Q = "nb_rx_q";//$NON-NLS-1$
+    private static final String NB_TX_Q = "nb_tx_q";//$NON-NLS-1$
+    private static final String NB_RX = "nb_rx"; //$NON-NLS-1$
+    private static final String NB_PKTS = "nb_pkts"; //$NON-NLS-1$
+    private static final String RC = "rc"; //$NON-NLS-1$
+
+
+    // ------------------------------------------------------------------------
+    // Event names
+    // ------------------------------------------------------------------------
+
+    /**
+     * This event is triggered when the app finishes configuring the Ethernet device.
+     *
+     * @return The event name
+     */
+    public static String eventEthdevConfigure() {
+        return ETH_DEV_CONFIGURE;
+    }
+
+    /**
+     * This event is generated when a burst of packets is received
+     *
+     * @return The event name
+     */
+    public static String eventEthdevRxqBurstNonEmpty() {
+        return ETH_DEV_RXQ_BURST_NON_EMPTY;
+    }
+
+    /**
+     * This event is generated when a burst of packets is sent
+     *
+     * @return The event name
+     */
+    public static String eventEthdevTxqBurst() {
+        return ETH_DEV_TXQ_BURST;
+    }
+    // ------------------------------------------------------------------------
+    // Event field names
+    // ------------------------------------------------------------------------
+
+    /**
+     * @return Number identifying a NIC port
+     */
+    public static String fieldPortId() {
+        return PORT_ID;
+    }
+
+    /**
+     * @return Number identifying a queue that is associated to a NIC port
+     */
+    public static String fieldQueueId() {
+        return QUEUE_ID;
+    }
+
+    /**
+     * @return The number of configured Rx queues
+     */
+    public static String fieldNbRxQ() {
+        return NB_RX_Q;
+    }
+
+    /**
+     * @return The number of configured Tx queues
+     */
+    public static String fieldNbTxQ() {
+        return NB_TX_Q;
+    }
+
+    /**
+     * @return The number of packets received
+     */
+    public static String fieldNbRxPkts() {
+        return NB_RX;
+    }
+
+    /**
+     * @return The number of packets transmitted
+     */
+    public static String fieldNbPkts() {
+        return NB_PKTS;
+    }
+
+    /**
+     * @return Code indicating whether the operation was successfull or not
+     */
+    public static String fieldRc() {
+        return RC;
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevRateAnalysis.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevRateAnalysis.java
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
+
+import java.util.Collections;
+
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement.PriorityLevel;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAnalysisEventRequirement;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTrace;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This analysis calculates the speed of packets received or transmitted from
+ * Ethernet NICs queues.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevRateAnalysis extends TmfStateSystemAnalysisModule {
+
+    /** The ID of this analysis module */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.analysis"; //$NON-NLS-1$
+
+    private final TmfAbstractAnalysisRequirement REQUIREMENT = new TmfAnalysisEventRequirement(ImmutableList.of(
+            DpdkEthdevEventLayout.eventEthdevConfigure()), PriorityLevel.AT_LEAST_ONE);
+
+    @Override
+    protected ITmfStateProvider createStateProvider() {
+        ITmfTrace trace = checkNotNull(getTrace());
+
+        if (trace instanceof TmfTrace) {
+            return new DpdkEthdevRateStateProvider(trace, ID);
+        }
+
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Iterable<TmfAbstractAnalysisRequirement> getAnalysisRequirements() {
+        return Collections.singleton(REQUIREMENT);
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevRateStateProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEthdevRateStateProvider.java
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.AbstractDpdkStateProvider;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * State provider for the Ethernet packet rate (or speed) analysis
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevRateStateProvider extends AbstractDpdkStateProvider {
+
+    private static final int VERSION = 1;
+
+    /** Map events needed for this analysis with their handler functions */
+    private @Nullable Map<String, IDpdkEventHandler> fEventNames;
+
+    /**
+     * State provider constructor
+     * @param trace
+     *            trace
+     * @param id
+     *            id
+     */
+    protected DpdkEthdevRateStateProvider(ITmfTrace trace, String id) {
+        super(trace, id);
+    }
+
+    /**
+     * Get the version of this state provider
+     */
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    /**
+     * Get a new instance
+     */
+    @Override
+    public ITmfStateProvider getNewInstance() {
+        return new DpdkEthdevRateStateProvider(this.getTrace(), DpdkEthdevRateAnalysis.ID);
+    }
+
+
+
+    @Override
+    protected @Nullable IDpdkEventHandler getEventHandler(String eventName) {
+        if (fEventNames == null) {
+            ImmutableMap.Builder<String, IDpdkEventHandler> builder = ImmutableMap.builder();
+            IDpdkEventHandler ethdevEventHandler = new DpdkEthdevEventHandler();
+            builder.put(DpdkEthdevEventLayout.eventEthdevConfigure(), ethdevEventHandler);
+            builder.put(DpdkEthdevEventLayout.eventEthdevRxqBurstNonEmpty(), ethdevEventHandler);
+            builder.put(DpdkEthdevEventLayout.eventEthdevTxqBurst(), ethdevEventHandler);
+            fEventNames = builder.build();
+        }
+        if (fEventNames != null) {
+            return fEventNames.get(eventName);
+        }
+        return null;
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEtherRateDataProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEtherRateDataProvider.java
@@ -1,0 +1,366 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
+import org.eclipse.tracecompass.tmf.core.model.CommonStatusMessage;
+import org.eclipse.tracecompass.tmf.core.model.IOutputStyleProvider;
+import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
+import org.eclipse.tracecompass.tmf.core.model.OutputStyleModel;
+import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
+import org.eclipse.tracecompass.tmf.core.model.YModel;
+import org.eclipse.tracecompass.tmf.core.model.filters.SelectionTimeQueryFilter;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.AbstractTreeCommonXDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.IYModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfXYAxisDescription;
+import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
+import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+/**
+ * This data provider will return a XY model (model is wrapped in a response)
+ * based on a query filter. The model returned is related to the DPDK Ethernet throughput views
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherRateDataProvider extends AbstractTreeCommonXDataProvider<DpdkEthdevRateAnalysis, TmfTreeDataModel>
+        implements IOutputStyleProvider {
+
+    /**
+     * Extension point ID.
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.dataprovider"; //$NON-NLS-1$
+
+    /**
+     * Title used to create XY models for the {@link DpdkEtherRateDataProvider}.
+     */
+    protected static final String PROVIDER_TITLE = Objects.requireNonNull("Dpdk Ethernet Device Throughput"); //$NON-NLS-1$
+
+    private static final String BASE_STYLE = "base"; //$NON-NLS-1$
+    private static final Map<String, OutputElementStyle> STATE_MAP;
+    private static final String BINARY_SPEED_UNIT = "/s"; //$NON-NLS-1$
+    private static final String NICS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_RateDataProvider_NICs);
+    private static final String RX_QS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_RateDataProvider_NIC_RX);
+    private static final String TX_QS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_RateDataProvider_NIC_TX);
+    private static final List<Pair<String, String>> COLOR_LIST = IODataPalette.getColors();
+    private static final TmfXYAxisDescription Y_AXIS_DESCRIPTION = new TmfXYAxisDescription(Objects.requireNonNull(Messages.DpdkEthdev_RateDataProvider_YAxis), BINARY_SPEED_UNIT, DataType.NUMBER);
+    private static final List<String> SUPPORTED_STYLES = ImmutableList.of(
+            StyleProperties.SeriesStyle.SOLID,
+            StyleProperties.SeriesStyle.DASH,
+            StyleProperties.SeriesStyle.DOT,
+            StyleProperties.SeriesStyle.DASHDOT,
+            StyleProperties.SeriesStyle.DASHDOTDOT);
+
+    static {
+        // Create the base style
+        ImmutableMap.Builder<String, OutputElementStyle> builder = new ImmutableMap.Builder<>();
+        builder.put(BASE_STYLE, new OutputElementStyle(null, ImmutableMap.of(StyleProperties.SERIES_TYPE, StyleProperties.SeriesType.AREA, StyleProperties.WIDTH, 1.0f)));
+        STATE_MAP = builder.build();
+    }
+
+    /**
+     * Class for encapsulating all the values required to build a series.
+     */
+    private static final class NicQueueBuilder {
+
+        private static final double SECONDS_PER_NANOSECOND = 1E-9;
+        private final long fId;
+        /** This series' represent the number of packets received or transmitted by a NIC port queue */
+        public final int fQueueQuark;
+        private final String fName;
+        private final double[] fValues;
+        private double fPrevCount;
+
+        /**
+         * Constructor
+         *
+         * @param id
+         *            the series Id
+         * @param nicQueueQuark
+         *            queue's quark
+         * @param name
+         *            name of this series
+         * @param length
+         *            desired length of the series
+         */
+        private NicQueueBuilder(long id, int nicQueueQuark, String name, int length) {
+            fId = id;
+            fQueueQuark = nicQueueQuark;
+            fName = name;
+            fValues = new double[length];
+        }
+
+        private void setPrevCount(double prevCount) {
+            fPrevCount = prevCount;
+        }
+
+        /**
+         * Update the value for the counter at the desired index.
+         *
+         * @param pos
+         *            index to update
+         * @param newCount
+         *            new number of read / written sectors
+         * @param deltaT
+         *            time difference to the previous value for interpolation
+         */
+        private void updateValue(int pos, double newCount, long deltaT) {
+            /**
+             * Linear interpolation to compute the queue throughput between time
+             * and the previous time, from the number of packets received or sent at each time.
+             */
+            fValues[pos] = (newCount - fPrevCount) / (SECONDS_PER_NANOSECOND * deltaT);
+            fPrevCount = newCount;
+        }
+
+        private IYModel build() {
+            return new YModel(fId, fName, fValues, Y_AXIS_DESCRIPTION);
+        }
+    }
+
+    /**
+     * Create an instance of {@link DpdkEtherRateDataProvider}. Returns a null
+     * instance if the analysis module is not found.
+     *
+     * @param trace
+     *            A trace on which we are interested to fetch a model
+     * @return A {@link DpdkEtherRateDataProvider} instance. If analysis module is not
+     *         found, it returns null
+     */
+    public static @Nullable DpdkEtherRateDataProvider create(ITmfTrace trace) {
+        DpdkEthdevRateAnalysis module = TmfTraceUtils.getAnalysisModuleOfClass(trace, DpdkEthdevRateAnalysis.class, DpdkEthdevRateAnalysis.ID);
+        if (module != null) {
+            module.schedule();
+            return new DpdkEtherRateDataProvider(trace, module);
+        }
+        return null;
+    }
+
+    /**
+     * Constructor
+     */
+    private DpdkEtherRateDataProvider(ITmfTrace trace, DpdkEthdevRateAnalysis module) {
+        super(trace, module);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * Get parts of the XY tree that are related to the RX and TX queues
+     *
+     * @param ss
+     *            State System
+     * @param qsQuark
+     *            Queues list quark
+     * @param nicName
+     *            Name of the NIC to which the queues belong
+     * @param nicId
+     *            Id of the related NIC
+     * @return a list of {@link TmfTreeDataModel}
+     */
+    List<TmfTreeDataModel> getQueuesTree(ITmfStateSystem ss, int qsQuark, String nicName, long nicId) {
+        int i = 0;
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        boolean isRxQueue = true;
+
+        try {
+            if(ss.getAttributeName(qsQuark).equals(Attributes.TX_Q)) {
+                isRxQueue = false;
+            }
+
+            long qsId = getId(qsQuark);
+            nodes.add(new TmfTreeDataModel(qsId, nicId, Collections.singletonList(isRxQueue? RX_QS_LABEL: TX_QS_LABEL), false, null));
+            for (Integer queueQuark : ss.getSubAttributes(qsQuark, false)) {
+                String queueName = ss.getAttributeName(queueQuark);
+                long queueId = getId(queueQuark);
+
+                // get colors for this queue corresponding to their types (reception or transmission)
+                Pair<String, String> pair = COLOR_LIST.get(i % COLOR_LIST.size());
+                String seriesStyle = SUPPORTED_STYLES.get((i / COLOR_LIST.size()) % SUPPORTED_STYLES.size());
+
+                if (queueQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                    nodes.add(new TmfTreeDataModel(queueId, qsId, Collections.singletonList(queueName), true,
+                            new OutputElementStyle(BASE_STYLE, ImmutableMap.of(
+                                    StyleProperties.COLOR, isRxQueue? pair.getFirst() : pair.getSecond(),
+                                    StyleProperties.SERIES_STYLE, seriesStyle,
+                                    StyleProperties.STYLE_NAME,
+                                    nicName + '/' + RX_QS_LABEL + '/' + queueName))));
+                }
+
+                i++;
+            }
+        } catch (IndexOutOfBoundsException e) {
+            Activator.getInstance().logWarning("A DPDK event (" + DpdkEthdevEventLayout.eventEthdevConfigure() + ") is missing"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return nodes;
+    }
+
+    @Override
+    protected TmfTreeModel<TmfTreeDataModel> getTree(ITmfStateSystem ss, Map<String, Object> parameters, @Nullable IProgressMonitor monitor) {
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        long rootId = getId(ITmfStateSystem.ROOT_ATTRIBUTE);
+        nodes.add(new TmfTreeDataModel(rootId, -1, Collections.singletonList(Objects.requireNonNull(getTrace().getName())), false, null));
+
+        try {
+            int nicsQuark = ss.getQuarkAbsolute(Attributes.NICS);
+            long nicsId = getId(nicsQuark);
+            nodes.add(new TmfTreeDataModel(nicsId, rootId, Collections.singletonList(NICS_LABEL), false, null));
+
+            for (Integer nicQuark : ss.getQuarks(Attributes.NICS, "*")) { //$NON-NLS-1$
+                String nicName = ss.getAttributeName(nicQuark);
+                long nicId = getId(nicQuark);
+                nodes.add(new TmfTreeDataModel(nicId, nicsId, Collections.singletonList(nicName), false, null));
+
+                int rxQsQuark = ss.optQuarkRelative(nicQuark, Attributes.RX_Q);
+                int txQsQuark = ss.optQuarkRelative(nicQuark, Attributes.TX_Q);
+                if (rxQsQuark == ITmfStateSystem.INVALID_ATTRIBUTE && txQsQuark == ITmfStateSystem.INVALID_ATTRIBUTE) {
+                    continue;
+                }
+
+                nodes.addAll(getQueuesTree(ss, rxQsQuark, nicName, nicId));
+                nodes.addAll(getQueuesTree(ss, txQsQuark, nicName, nicId));
+
+            }
+        } catch (AttributeNotFoundException e) {
+            Activator.getInstance().logError("Error getting the root attribute of " + Attributes.NICS); //$NON-NLS-1$
+        }
+        return new TmfTreeModel<>(Collections.emptyList(), nodes);
+    }
+
+    /**
+     * Extract a packets counts
+     *
+     * @param queueQuark
+     *          quark of the NIC queue
+     * @param states
+     *          states
+     * @return
+     *          number of received or transmitted packets
+     */
+    public static double extractCount(int queueQuark, List<ITmfStateInterval> states) {
+        Object stateValue = states.get(queueQuark).getValue();
+        double count = (stateValue instanceof Number) ? ((Number) stateValue).doubleValue() : 0.0;
+        return count;
+    }
+
+    @Override
+    protected @Nullable Collection<IYModel> getYSeriesModels(ITmfStateSystem ss, Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) throws StateSystemDisposedException {
+        SelectionTimeQueryFilter filter = FetchParametersUtils.createSelectionTimeQuery(fetchParameters);
+        if (filter == null) {
+            return null;
+        }
+        long[] xValues = filter.getTimesRequested();
+        List<NicQueueBuilder> builders = initBuilders(ss, filter);
+        if (builders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        long currentEnd = ss.getCurrentEndTime();
+        long prevTime = filter.getStart();
+        if (prevTime >= ss.getStartTime() && prevTime <= currentEnd) {
+            // reuse the results from the full query
+            List<ITmfStateInterval> states = ss.queryFullState(prevTime);
+
+            for (NicQueueBuilder entry : builders) {
+                entry.setPrevCount(extractCount(entry.fQueueQuark, /*ss,*/ states/*, prevTime*/));
+            }
+        }
+
+        for (int i = 1; i < xValues.length; i++) {
+            if (monitor != null && monitor.isCanceled()) {
+                return null;
+            }
+            long time = xValues[i];
+            if (time > currentEnd) {
+                break;
+            } else if (time >= ss.getStartTime()) {
+                List<ITmfStateInterval> states = ss.queryFullState(time);
+
+                for (NicQueueBuilder entry : builders) {
+                    double count = extractCount(entry.fQueueQuark, states);
+                    entry.updateValue(i, count, time - prevTime);
+                }
+            }
+            prevTime = time;
+        }
+        return ImmutableList.copyOf(Iterables.transform(builders, NicQueueBuilder::build));
+    }
+
+
+    private List<NicQueueBuilder> initBuilders(ITmfStateSystem ss, SelectionTimeQueryFilter filter) {
+        int length = filter.getTimesRequested().length;
+        List<NicQueueBuilder> builders = new ArrayList<>();
+
+        for (Entry<Long, Integer> entry : getSelectedEntries(filter).entrySet()) {
+            long id = Objects.requireNonNull(entry.getKey());
+            int quark = Objects.requireNonNull(entry.getValue());
+
+            if((quark == ITmfStateSystem.ROOT_ATTRIBUTE) ||
+                    (ss.getParentAttributeQuark(quark) == ITmfStateSystem.ROOT_ATTRIBUTE)) {
+                continue;
+            }
+
+            int parentQuark = ss.getParentAttributeQuark(quark);
+            if(parentQuark != ITmfStateSystem.INVALID_ATTRIBUTE &&
+                    ((ss.getAttributeName(parentQuark).equals(Attributes.RX_Q) ||
+                            ss.getAttributeName(parentQuark).equals(Attributes.TX_Q)))) {
+                int nicQuark = ss.getParentAttributeQuark(parentQuark);
+                String name = getTrace().getName() + '/' + ss.getAttributeName(nicQuark)  + '/' + ss.getAttributeName(parentQuark)  + '/' + ss.getAttributeName(quark);
+                builders.add(new NicQueueBuilder(id, quark, name, length));
+            }
+
+        }
+        return builders;
+    }
+
+    @Override
+    protected boolean isCacheable() {
+        return true;
+    }
+
+    @Override
+    protected String getTitle() {
+        return PROVIDER_TITLE;
+    }
+
+    @Override
+    public TmfModelResponse<OutputStyleModel> fetchStyle(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
+        return new TmfModelResponse<>(new OutputStyleModel(STATE_MAP), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEtherRateDataProviderFactory.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/DpdkEtherRateDataProviderFactory.java
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.ITmfTreeXYDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfTreeXYCompositeDataProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+/**
+ * Factory to create instances of the {@link DpdkEtherRateDataProvider}.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherRateDataProviderFactory implements IDataProviderFactory {
+    private static final Predicate<? super ITmfTrace> PREDICATE = t -> TmfTraceUtils.getAnalysisModuleOfClass(t, DpdkEthdevRateAnalysis.class, DpdkEthdevRateAnalysis.ID) != null;
+    private static final IDataProviderDescriptor DESCRIPTOR = new DataProviderDescriptor.Builder()
+            .setId( DpdkEtherRateDataProvider.ID)
+            .setName("Dpdk Ethernet Rate") //$NON-NLS-1$
+            .setDescription("XY chart illustrating the speed rate of DPDK Ethernet NIC ports") //$NON-NLS-1$
+            .setProviderType(ProviderType.TREE_TIME_XY)
+            .build();
+
+    @Override
+    public @Nullable ITmfTreeXYDataProvider<? extends ITmfTreeDataModel> createProvider(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        if (traces.size() == 1) {
+            return DpdkEtherRateDataProvider.create(trace);
+        }
+        return TmfTreeXYCompositeDataProvider.create(traces, DpdkEtherRateDataProvider.PROVIDER_TITLE, DpdkEtherRateDataProvider.ID);
+    }
+
+    @Override
+    public Collection<IDataProviderDescriptor> getDescriptors(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        return Iterables.any(traces, PREDICATE) ? Collections.singletonList(DESCRIPTOR) : Collections.emptyList();
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/IODataPalette.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/IODataPalette.java
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+import java.util.List;
+
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A class providing various color pairs for receive/sent data. Receives have a
+ * blueish tint, while the Sends are reddish.
+ *
+ * Those colors are taken from the {@href https://colorbrewer2.org} from
+ * sequential palettes of blues and reds with 6 colors, eliminating the first
+ * paler one
+ *
+ * @author Geneviève Bastien
+ */
+public class IODataPalette {
+
+    private static final List<Pair<String, String>> COLOR_LIST;
+
+    static {
+        ImmutableList.Builder<Pair<String, String>> colorBuilder = new ImmutableList.Builder<>();
+
+        /* First color of each pair is blueish, second reddish */
+        // Middle color: blue sky, peach red
+        colorBuilder.add(new Pair<>(
+                "#6baed6", //$NON-NLS-1$
+                "#fb6a4a")); //$NON-NLS-1$
+        // Darker: blueberry color, dark red going on dark maroon
+        colorBuilder.add(new Pair<>(
+                "#08519c", //$NON-NLS-1$
+                "#a50f15")); //$NON-NLS-1$
+        // Paler: pale grey blue, very pale red orangeish
+        colorBuilder.add(new Pair<>(
+                "#c6dbef", //$NON-NLS-1$
+                "#fcbba1")); //$NON-NLS-1$
+        // Between middle and darker: tahiti sea and red ferrari
+        colorBuilder.add(new Pair<>(
+                "#3182bd", //$NON-NLS-1$
+                "#de2d26")); //$NON-NLS-1$
+        // Between paler and middle: light turquoise, salmon
+        colorBuilder.add(new Pair<>(
+                "#9ecae1", //$NON-NLS-1$
+                "#fc9272")); //$NON-NLS-1$
+
+        COLOR_LIST = colorBuilder.build();
+    }
+
+    private IODataPalette() {
+        // Do nothing
+    }
+
+    /**
+     * Get the list of color pairs for read/write data. For each element in the
+     * list, the first element of the pair is the read color (blueish) and the
+     * second color is the write (reddish).
+     *
+     * The color strings have an hexadecimal format: #xxxxxx
+     *
+     * @return The list of color pairs for read/write
+     */
+    public static List<Pair<String, String>> getColors() {
+        return COLOR_LIST;
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/Messages.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for {@link DpdkEtherRateDataProvider}
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings("javadoc")
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.messages"; //$NON-NLS-1$
+    public static @Nullable String DpdkEthdev_RateDataProvider_NICs;
+    public static @Nullable String DpdkEthdev_RateDataProvider_NIC_RX;
+    public static @Nullable String DpdkEthdev_RateDataProvider_NIC_TX;
+    public static @Nullable String DpdkEthdev_RateDataProvider_YAxis;
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/messages.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2024 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+DpdkEthdev_RateDataProvider_NICs=NIC Port
+DpdkEthdev_RateDataProvider_NIC_RX=RX
+DpdkEthdev_RateDataProvider_NIC_TX=TX
+DpdkEthdev_RateDataProvider_YAxis=#/s

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/package-info.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/rate/analysis/package-info.java
@@ -1,0 +1,13 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+@org.eclipse.jdt.annotation.NonNullByDefault
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis;
+

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/Attributes.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/Attributes.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+/**
+ * This interface defines all the attribute names used in the state system.
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings({ "nls" })
+public interface Attributes {
+
+    /* First-level attributes */
+
+    /** Root attribute for DPDK Ethdev Nics */
+    String POLL_THREADS = "Threads";
+    /** Reception Queues */
+    /** */
+    String SPIN_STATUS = "Spin";
+    /** */
+    String ACTIVE_STATUS = "Active";
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevEventHandler.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevEventHandler.java
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+import java.util.Objects;
+
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
+import org.eclipse.tracecompass.statesystem.core.StateSystemBuilderUtils;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateValueTypeException;
+import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+
+/**
+ * Event handler for the DPDK events required for the
+ * {@link DpdkEthdevSpinAnalysisModule} analysis
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevEventHandler implements IDpdkEventHandler {
+
+    /* Attribute names */
+    private static final String POLL_THREADS = Objects.requireNonNull(Attributes.POLL_THREADS);
+
+    DpdkEthdevEventHandler() {
+        // Nothing here
+    }
+
+    /**
+     * Update the count of received or transmitted packets on the state system
+     *
+     * @param ssb
+     *            state system builder
+     * @param queueQuark
+     *            quark of the the Ethernet device queue
+     * @param nbPkts
+     *            number of packets received or transmitted
+     * @param ts
+     *            time to use for state change
+     */
+    public void updateCounts(ITmfStateSystemBuilder ssb, int queueQuark, Integer nbPkts, long ts) {
+        if (nbPkts <= 0) {
+            return;
+        }
+        try {
+            StateSystemBuilderUtils.incrementAttributeLong(ssb, ts, queueQuark, nbPkts);
+        } catch (StateValueTypeException e) {
+            Activator.getInstance().logWarning(getClass().getName() + ": problem accessing the state of a NIC queue (Quark =" + String.valueOf(queueQuark) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    @Override
+    public void handleEvent(ITmfStateSystemBuilder ssb, ITmfEvent event) {
+        long ts = event.getTimestamp().getValue();
+        String eventName = event.getName();
+
+        Integer portId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldPortId());
+        Integer queueId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldQueueId());
+        String threadName = event.getContent().getFieldValue(String.class, DpdkEthdevEventLayout.fieldThreadName());
+        Integer cpuId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldCpuId());
+
+        int threadQuark = ssb.getQuarkAbsoluteAndAdd(POLL_THREADS, threadName + "/" + cpuId); //$NON-NLS-1$
+        int queueQark = ssb.getQuarkRelativeAndAdd(threadQuark, "P" + Objects.requireNonNull(portId).toString() + "/Q" + Objects.requireNonNull(queueId).toString()); //$NON-NLS-1$ //$NON-NLS-2$
+
+        if (eventName.equals(DpdkEthdevEventLayout.eventEthdevRxqBurstEmpty())) {
+            ssb.modifyAttribute(ts, Attributes.SPIN_STATUS, queueQark);
+        } else if (eventName.equals(DpdkEthdevEventLayout.eventEthdevRxqBurstNonEmpty())) {
+            ssb.modifyAttribute(ts, Attributes.ACTIVE_STATUS, queueQark);
+        }
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevEventLayout.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevEventLayout.java
@@ -1,0 +1,81 @@
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+/**
+ * The event layout class to specify event names and their fields
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevEventLayout {
+
+    /* Event names */
+    private static final String ETH_DEV_RXQ_BURST_EMPTY = "lib.ethdev.rx.burst.empty"; //$NON-NLS-1$
+    private static final String ETH_DEV_RXQ_BURST_NON_EMPTY = "lib.ethdev.rx.burst.nonempty"; //$NON-NLS-1$
+
+    /* Event field names */
+    private static final String PORT_ID = "port_id"; //$NON-NLS-1$
+    private static final String QUEUE_ID = "queue_id"; //$NON-NLS-1$
+    private static final String NB_RX = "nb_rx"; //$NON-NLS-1$
+    private static final String THREAD_NAME = "context.name"; //$NON-NLS-1$
+    private static final String CPU_ID = "context.cpu_id"; //$NON-NLS-1$
+
+    // ------------------------------------------------------------------------
+    // Event names
+    // ------------------------------------------------------------------------
+
+    /**
+     * This event is generated when a burst of packets is received
+     *
+     * @return The event name
+     */
+    public static String eventEthdevRxqBurstEmpty() {
+        return ETH_DEV_RXQ_BURST_EMPTY;
+    }
+
+    /**
+     * This event is generated when a burst of packets is received
+     *
+     * @return The event name
+     */
+    public static String eventEthdevRxqBurstNonEmpty() {
+        return ETH_DEV_RXQ_BURST_NON_EMPTY;
+    }
+
+    // ------------------------------------------------------------------------
+    // Event field names
+    // ------------------------------------------------------------------------
+
+    /**
+     * @return Number identifying a NIC port
+     */
+    public static String fieldPortId() {
+        return PORT_ID;
+    }
+
+    /**
+     * @return Number identifying a queue that is associated to a NIC port
+     */
+    public static String fieldQueueId() {
+        return QUEUE_ID;
+    }
+
+    /**
+     * @return The number of packets received
+     */
+    public static String fieldNbRxPkts() {
+        return NB_RX;
+    }
+
+    /**
+     * @return The name of the thread issuing the DPDK event
+     */
+    public static String fieldThreadName() {
+        return THREAD_NAME;
+    }
+
+    /**
+     * @return The identifier of the CPU on which the DPDK event was recorded
+     */
+    public static String fieldCpuId() {
+        return CPU_ID;
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevSpinAnalysisModule.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevSpinAnalysisModule.java
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.TimeRangeException;
+import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement.PriorityLevel;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAnalysisEventRequirement;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTrace;
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This analysis provides an estimation for the percentage of time a PMD thread
+ * was doing a real work (e.g., fetching packets, processing them, etc.). It is
+ * based on two events: the "lib.ethdev.rx.burst.empty" event denotes an empty
+ * poll, and the "lib.ethdev.rx.burst.nonempty" event denotes a successful poll,
+ * where one or many packets were retrieved.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevSpinAnalysisModule extends TmfStateSystemAnalysisModule {
+
+    /** The ID of this analysis module */
+    public static final String ID = "org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis"; //$NON-NLS-1$
+
+    private final TmfAbstractAnalysisRequirement REQUIREMENT = new TmfAnalysisEventRequirement(ImmutableList.of(
+            DpdkEthdevEventLayout.eventEthdevRxqBurstEmpty(), DpdkEthdevEventLayout.eventEthdevRxqBurstNonEmpty()), PriorityLevel.AT_LEAST_ONE);
+
+    @Override
+    protected ITmfStateProvider createStateProvider() {
+        ITmfTrace trace = checkNotNull(getTrace());
+
+        if (trace instanceof TmfTrace) {
+            return new DpdkEthdevSpinStateProvider(trace, ID);
+        }
+
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Iterable<TmfAbstractAnalysisRequirement> getAnalysisRequirements() {
+        return Collections.singleton(REQUIREMENT);
+    }
+
+    /**
+     * Calculates thread usage witin a specific time interval
+     *
+     * @param start
+     *            start timestamp
+     * @param end
+     *            end timestamp
+     * @return A map of Thread names -> time spent in empty or active iterations
+     */
+    public Map<String, Pair<Long, Long>> getThreadUsageInRange(Set<@NonNull Integer> threads, long start, long end) {
+        Map<String, Pair<Long, Long>> map = new HashMap<>();
+
+        ITmfTrace trace = getTrace();
+        ITmfStateSystem threadSs = getStateSystem();
+        if (trace == null || threadSs == null) {
+            return map;
+        }
+
+        long startTime = Math.max(start, threadSs.getStartTime());
+        long endTime = Math.min(end, threadSs.getCurrentEndTime());
+        if (endTime < startTime) {
+            return map;
+        }
+
+        try {
+            int threadsNode = threadSs.getQuarkAbsolute(Attributes.POLL_THREADS);
+            for (int threadNode : threadSs.getSubAttributes(threadsNode, false)) {
+                if (!threads.contains(threadNode)) {
+                    continue;
+                }
+
+                String curThreadName = threadSs.getAttributeName(threadNode);
+                long countActive = 0;
+                long countSpin = 0;
+                for (int queueNode : threadSs.getSubAttributes(threadNode, false)) {
+                    long ts = startTime;
+                    do {
+                        ITmfStateInterval stateInterval = threadSs.querySingleState(ts, queueNode);
+                        Object stateValue = stateInterval.getStateValue().unboxValue();
+                        long stateStart = stateInterval.getStartTime();
+                        long stateEnd = stateInterval.getEndTime();
+
+                        if (stateValue != null) {
+                            String threadState = (String) stateValue;
+                            if (threadState.equals(Attributes.ACTIVE_STATUS)) {
+                                countActive += interpolateCount(startTime, endTime, stateEnd, stateStart);
+                            } else if (threadState.equals(Attributes.SPIN_STATUS)) {
+                                countSpin += interpolateCount(startTime, endTime, stateEnd, stateStart);
+                            }
+                        }
+                        ts = Math.min(stateEnd, endTime) + 1;
+                    } while (ts < endTime);
+                }
+
+                map.put(curThreadName, new Pair<>(countActive, countSpin));
+
+            }
+        } catch (TimeRangeException | AttributeNotFoundException | StateSystemDisposedException e) {
+        }
+
+        return map;
+    }
+
+    private static long interpolateCount(long startTime, long endTime, long spinningEnd, long spinningStart) {
+
+        long count = spinningEnd - spinningStart;
+
+        /* sanity check */
+        if (count > 0) {
+            if (startTime > spinningStart) {
+                count -= (startTime - spinningStart);
+            }
+
+            if (endTime < spinningEnd) {
+                count -= (spinningEnd - endTime);
+            }
+        }
+        return count;
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevSpinStateProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEthdevSpinStateProvider.java
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.AbstractDpdkStateProvider;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * State provider for the {@link DpdkEthdevSpinAnalysisModule} analysis
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevSpinStateProvider extends AbstractDpdkStateProvider {
+
+    private static final int VERSION = 1;
+
+    /** Map events needed for this analysis with their handler functions */
+    private @Nullable Map<String, IDpdkEventHandler> fEventNames;
+
+    /**
+     * Constructor
+     *
+     * @param trace
+     *            trace
+     * @param id
+     *            id
+     */
+    protected DpdkEthdevSpinStateProvider(ITmfTrace trace, String id) {
+        super(trace, id);
+    }
+
+    /**
+     * Get the version of this state provider
+     */
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    /**
+     * Get a new instance
+     */
+    @Override
+    public ITmfStateProvider getNewInstance() {
+        return new DpdkEthdevSpinStateProvider(this.getTrace(), DpdkEthdevSpinAnalysisModule.ID);
+    }
+
+
+
+    @Override
+    protected @Nullable IDpdkEventHandler getEventHandler(String eventName) {
+        if (fEventNames == null) {
+            ImmutableMap.Builder<String, IDpdkEventHandler> builder = ImmutableMap.builder();
+            IDpdkEventHandler ethdevEventHandler = new DpdkEthdevEventHandler();
+            builder.put(DpdkEthdevEventLayout.eventEthdevRxqBurstEmpty(), ethdevEventHandler);
+            builder.put(DpdkEthdevEventLayout.eventEthdevRxqBurstNonEmpty(), ethdevEventHandler);
+            fEventNames = builder.build();
+        }
+        if (fEventNames != null) {
+            return fEventNames.get(eventName);
+        }
+        return null;
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEtherSpinDataProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEtherSpinDataProvider.java
@@ -1,0 +1,238 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.tmf.core.model.CommonStatusMessage;
+import org.eclipse.tracecompass.tmf.core.model.IOutputStyleProvider;
+import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
+import org.eclipse.tracecompass.tmf.core.model.OutputStyleModel;
+import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
+import org.eclipse.tracecompass.tmf.core.model.YModel;
+import org.eclipse.tracecompass.tmf.core.model.filters.SelectionTimeQueryFilter;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.AbstractTreeCommonXDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.IYModel;
+import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
+import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * This data provider will return a XY model, showing the % of occupancy of a
+ * PMD thread
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherSpinDataProvider extends AbstractTreeCommonXDataProvider<DpdkEthdevSpinAnalysisModule, TmfTreeDataModel>
+        implements IOutputStyleProvider {
+
+    /**
+     * Extension point ID.
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.dataprovider"; //$NON-NLS-1$
+
+    /**
+     * Title used to create XY models for the {@link DpdkEtherSpinDataProvider}.
+     */
+    protected static final String PROVIDER_TITLE = Objects.requireNonNull("DPDK Threads Effective CPU Usage"); //$NON-NLS-1$
+
+    private static final String BASE_STYLE = "base"; //$NON-NLS-1$
+
+    private static final String THREADS_LABEL = Objects.requireNonNull(Messages.DpdkEthdevSpin_DataProvider_Threads);
+
+    private static final Map<String, OutputElementStyle> STATE_MAP;
+
+    static {
+        // Create the base style
+        ImmutableMap.Builder<String, OutputElementStyle> builder = new ImmutableMap.Builder<>();
+        builder.put(BASE_STYLE, new OutputElementStyle(null, ImmutableMap.of(StyleProperties.SERIES_TYPE, StyleProperties.SeriesType.SCATTER, StyleProperties.WIDTH, 1.0f)));
+        STATE_MAP = builder.build();
+    }
+
+    /**
+     * Create an instance of {@link DpdkEtherSpinDataProvider}. Returns a null
+     * instance if the analysis module is not found.
+     *
+     * @param trace
+     *            A trace on which we are interested to fetch a model
+     * @return a {@link DpdkEtherSpinDataProvider} instance. If analysis module
+     *         is not found, it returns null
+     */
+    public static @Nullable DpdkEtherSpinDataProvider create(ITmfTrace trace) {
+        DpdkEthdevSpinAnalysisModule module = TmfTraceUtils.getAnalysisModuleOfClass(trace, DpdkEthdevSpinAnalysisModule.class, DpdkEthdevSpinAnalysisModule.ID);
+        if (module != null) {
+            module.schedule();
+            return new DpdkEtherSpinDataProvider(trace, module);
+        }
+        return null;
+    }
+
+    /**
+     * Constructor
+     */
+    private DpdkEtherSpinDataProvider(ITmfTrace trace, DpdkEthdevSpinAnalysisModule module) {
+        super(trace, module);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    protected TmfTreeModel<TmfTreeDataModel> getTree(ITmfStateSystem ss, Map<String, Object> parameters, @Nullable IProgressMonitor monitor) {
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        long rootId = getId(ITmfStateSystem.ROOT_ATTRIBUTE);
+        nodes.add(new TmfTreeDataModel(rootId, -1, Collections.singletonList(Objects.requireNonNull(getTrace().getName())), false, null));
+
+        try {
+            int threadsQuark = ss.getQuarkAbsolute(Attributes.POLL_THREADS);
+            long threadsId = getId(threadsQuark);
+            nodes.add(new TmfTreeDataModel(threadsId, rootId, Collections.singletonList(THREADS_LABEL), false, null));
+
+            for (Integer threadQuark : ss.getQuarks(Attributes.POLL_THREADS, "*")) { //$NON-NLS-1$
+                String threadName = ss.getAttributeName(threadQuark);
+                long threadId = getId(threadQuark);
+                nodes.add(new TmfTreeDataModel(threadId, threadsId, Collections.singletonList(threadName), false, null));
+            }
+        } catch (AttributeNotFoundException e) {
+            Activator.getInstance().logError("Error getting the root attribute of " + Attributes.POLL_THREADS); //$NON-NLS-1$
+        }
+        return new TmfTreeModel<>(Collections.emptyList(), nodes);
+    }
+
+    private static long getInitialPrevTime(SelectionTimeQueryFilter filter) {
+        /*
+         * Subtract from start time the same interval as the interval from start
+         * time to next time, ignoring duplicates in the times requested.
+         */
+        long startTime = filter.getStart();
+        for (long time : filter.getTimesRequested()) {
+            if (time > startTime) {
+                return startTime - (time - startTime);
+            }
+        }
+        return startTime;
+    }
+
+    @Override
+    protected @Nullable Collection<IYModel> getYSeriesModels(ITmfStateSystem ss, Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) throws StateSystemDisposedException {
+        SelectionTimeQueryFilter filter = FetchParametersUtils.createSelectionTimeQuery(fetchParameters);
+        if (filter == null) {
+            return null;
+        }
+
+        if (getSelectedEntries(filter).isEmpty()) {
+            return null;
+        }
+
+        Set<Integer> selectedThreads = new HashSet<>();
+
+        long[] xValues = filter.getTimesRequested();
+        Map<String, IYModel> selectedThreadValues = new HashMap<>();
+
+        for (Entry<Long, Integer> entry : getSelectedEntries(filter).entrySet()) {
+            int quark = Objects.requireNonNull(entry.getValue());
+
+            if ((quark == ITmfStateSystem.ROOT_ATTRIBUTE) ||
+                    (ss.getParentAttributeQuark(quark) == ITmfStateSystem.ROOT_ATTRIBUTE)) {
+                continue;
+            }
+            selectedThreads.add(quark);
+            String name = ss.getAttributeName(quark);
+            selectedThreadValues.put(name, new YModel(entry.getKey(), getTrace().getName() + '/' + name, new double[xValues.length]));
+        }
+
+        long prevTime = Math.max(getInitialPrevTime(filter), ss.getStartTime());
+        long currentEnd = ss.getCurrentEndTime();
+
+        for (int i = 0; i < xValues.length; i++) {
+            long time = xValues[i];
+            if (time < ss.getStartTime() || time > currentEnd) {
+                prevTime = time;
+                continue;
+            }
+            if (prevTime < time) {
+                Map<String, Pair<Long, Long>> threadUsageMap = getAnalysisModule().getThreadUsageInRange(selectedThreads, prevTime, time);
+                for (Entry<String, Pair<Long, Long>> entry : threadUsageMap.entrySet()) {
+                    IYModel values = selectedThreadValues.get(entry.getKey()/*
+                                                                             * threadName
+                                                                             */);
+                    if (values != null) {
+                        long countActive = Objects.requireNonNull(entry.getValue()).getFirst();
+                        long countSpin = Objects.requireNonNull(entry.getValue()).getSecond();
+                        values.getData()[i] = getPercentageValue(countActive, countSpin);
+                    }
+                }
+            } else if (i > 0) {
+                /* In case of duplicate time xValue copy previous yValues */
+                for (IYModel values : selectedThreadValues.values()) {
+                    values.getData()[i] = values.getData()[i - 1];
+                }
+            }
+            prevTime = time;
+            if (monitor != null && monitor.isCanceled()) {
+                return null;
+            }
+        }
+
+        ImmutableList.Builder<IYModel> ySeries = ImmutableList.builder();
+        for (IYModel entry : selectedThreadValues.values()) {
+            ySeries.add(entry);
+        }
+
+        return ySeries.build();
+    }
+
+    private static double getPercentageValue(long countActive, long countSpin) {
+        double value = (countActive + countSpin == 0) ? 0.0 : (double) countActive * 100 / (countActive + countSpin);
+        return value;
+    }
+
+    @Override
+    protected boolean isCacheable() {
+        return true;
+    }
+
+    @Override
+    protected String getTitle() {
+        return PROVIDER_TITLE;
+    }
+
+    @Override
+    public TmfModelResponse<OutputStyleModel> fetchStyle(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
+        return new TmfModelResponse<>(new OutputStyleModel(STATE_MAP), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEtherSpinDataProviderFactory.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/DpdkEtherSpinDataProviderFactory.java
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.ITmfTreeXYDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfTreeXYCompositeDataProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+/**
+ * Factory to create instances of the {@link DpdkEtherSpinDataProvider}.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherSpinDataProviderFactory implements IDataProviderFactory {
+    private static final Predicate<? super ITmfTrace> PREDICATE = t -> TmfTraceUtils.getAnalysisModuleOfClass(t, DpdkEthdevSpinAnalysisModule.class, DpdkEthdevSpinAnalysisModule.ID) != null;
+    private static final IDataProviderDescriptor DESCRIPTOR = new DataProviderDescriptor.Builder()
+            .setId(DpdkEtherSpinDataProvider.ID)
+            .setName("Dpdk Ethernet RX Spins") //$NON-NLS-1$
+            .setDescription("XY chart showing a rough estimate of PMD threads busyness based on the number of empy and full Rx spins") //$NON-NLS-1$
+            .setProviderType(ProviderType.TREE_TIME_XY)
+            .build();
+
+    @Override
+    public @Nullable ITmfTreeXYDataProvider<? extends ITmfTreeDataModel> createProvider(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        if (traces.size() == 1) {
+            return DpdkEtherSpinDataProvider.create(trace);
+        }
+        return TmfTreeXYCompositeDataProvider.create(traces, DpdkEtherSpinDataProvider.PROVIDER_TITLE, DpdkEtherSpinDataProvider.ID);
+    }
+
+    @Override
+    public Collection<IDataProviderDescriptor> getDescriptors(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        return Iterables.any(traces, PREDICATE) ? Collections.singletonList(DESCRIPTOR) : Collections.emptyList();
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/Messages.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for {@link DpdkEtherSpinDataProvider}
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings("javadoc")
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis.messages"; //$NON-NLS-1$
+
+    public static @Nullable String DpdkEthdevSpin_DataProvider_Threads;
+    public static @Nullable String DpdkEthdevSpin_DataProvider_YAxis;
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/messages.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2024 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+DpdkEthdevSpin_DataProvider_Threads=Threads
+DpdkEthdevSpin_DataProvider_YAxis=Count

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/package-info.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/spin/analysis/package-info.java
@@ -1,0 +1,13 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+@org.eclipse.jdt.annotation.NonNullByDefault
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis;
+

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/Attributes.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/Attributes.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+/**
+ * This interface defines all the attribute names used in the state system.
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings({ "nls" })
+public interface Attributes {
+
+    /* First-level attributes */
+
+    /** Root attribute for DPDK Ethdev Nics */
+    String NICS = "NICs";
+    /** Reception Queues */
+    String RX_Q = "Rx_Q";
+    /** Transmission Queues */
+    String TX_Q = "Tx_Q";
+    /** Packet Number */
+    String PKT_COUNT = "pkt_count";
+    /** Packet Size */
+    String PKT_SIZE = "pkt_size";
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevAnalysisModule.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevAnalysisModule.java
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (c) 2023 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
+
+import java.util.Collections;
+
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement.PriorityLevel;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAnalysisEventRequirement;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTrace;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This analysis calculates the reception and transmission throughput per
+ * Ethernet NIC queue.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevAnalysisModule extends TmfStateSystemAnalysisModule {
+
+    /** The ID of this analysis module */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.analysis"; //$NON-NLS-1$
+
+    private final TmfAbstractAnalysisRequirement REQUIREMENT = new TmfAnalysisEventRequirement(ImmutableList.of(
+            DpdkEthdevEventLayout.eventEthdevConfigure()), PriorityLevel.AT_LEAST_ONE);
+
+    @Override
+    protected ITmfStateProvider createStateProvider() {
+        ITmfTrace trace = checkNotNull(getTrace());
+
+        if (trace instanceof TmfTrace) {
+            return new DpdkEthdevStateProvider(trace, ID);
+        }
+
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Iterable<TmfAbstractAnalysisRequirement> getAnalysisRequirements() {
+        return Collections.singleton(REQUIREMENT);
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevEventHandler.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevEventHandler.java
@@ -1,0 +1,123 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import java.util.Objects;
+
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
+import org.eclipse.tracecompass.statesystem.core.StateSystemBuilderUtils;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateValueTypeException;
+import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+
+/**
+ * Event handler to handle the DPDK events required for the
+ * {@link DpdkEthdevAnalysisModule} analysis
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevEventHandler implements IDpdkEventHandler {
+
+    /* Attribute names */
+    private static final String ETH_NICS = Objects.requireNonNull(Attributes.NICS);
+    private static final String RX_Q = Objects.requireNonNull(Attributes.RX_Q);
+    private static final String TX_Q = Objects.requireNonNull(Attributes.TX_Q);
+    private static final String PKT_NB = Objects.requireNonNull(Attributes.PKT_COUNT);
+    private static final String PKT_SIZE = Objects.requireNonNull(Attributes.PKT_SIZE);
+
+    DpdkEthdevEventHandler() {
+        // Nothing here
+    }
+
+    /**
+     * Update the count of received or transmitted packets on the state system
+     *
+     * @param ts
+     *            timestamp to use for the state change
+     */
+    static private void createNicQueue(ITmfStateSystemBuilder ssb, int queueSetQuark, int nbQueues, long ts) {
+        if (nbQueues <= 0) {
+            return;
+        }
+
+        for (int i = 0; i < nbQueues; i++) {
+            ssb.getQuarkRelativeAndAdd(queueSetQuark, String.valueOf(i));
+        }
+    }
+
+    /**
+     * Update the count of received or transmitted packets on the state system
+     *
+     * @param ssb
+     *            state system builder
+     * @param queueQuark
+     *            quark of the the Ethernet device queue
+     * @param nbPkt
+     *            number of packets received or transmitted
+     * @param size
+     *            size of the packets in bytes
+     * @param ts
+     *            timestamp to use for the state change
+     */
+    public void updateCounts(ITmfStateSystemBuilder ssb, int queueQuark, Integer nbPkt, Integer size, long ts) {
+        try {
+            int pktNumberQuark = ssb.getQuarkRelativeAndAdd(queueQuark, PKT_NB);
+            StateSystemBuilderUtils.incrementAttributeLong(ssb, ts, pktNumberQuark, nbPkt);
+            int pktSizeQuark = ssb.getQuarkRelativeAndAdd(queueQuark, PKT_SIZE);
+            StateSystemBuilderUtils.incrementAttributeLong(ssb, ts, pktSizeQuark, size);
+        } catch (StateValueTypeException e) {
+            Activator.getInstance().logWarning(getClass().getName() + ": problem accessing the state of a NIC queue (Quark =" + String.valueOf(queueQuark) + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    @Override
+    public void handleEvent(ITmfStateSystemBuilder ssb, ITmfEvent event) {
+        Integer portId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldPortId());
+        long ts = event.getTimestamp().getValue();
+        String eventName = event.getName();
+
+        if (eventName.equals(DpdkEthdevEventLayout.eventEthdevConfigure())) {
+            Integer rc = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldRc());
+            Integer nbRxQueues = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbRxQ());
+            Integer nbTxQueues = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbTxQ());
+
+            if (Objects.requireNonNull(rc) == 0) {
+                // save the new Ethernet device on the satet system
+                int portQuark = ssb.getQuarkAbsoluteAndAdd(ETH_NICS, String.valueOf(portId));
+                int rxQueueQark = ssb.getQuarkRelativeAndAdd(portQuark, RX_Q);
+                createNicQueue(ssb, rxQueueQark, Objects.requireNonNull(nbRxQueues), ts);
+                int txQueueQark = ssb.getQuarkRelativeAndAdd(portQuark, TX_Q);
+                createNicQueue(ssb, txQueueQark, Objects.requireNonNull(nbTxQueues), ts);
+            } else {
+                Activator.getInstance().logWarning("The event " + DpdkEthdevEventLayout.eventEthdevConfigure() + " presents a Non-Null RC value"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+
+        } else if (eventName.equals(DpdkEthdevEventLayout.eventProfileEthdevRxBurst())) { // **
+            Integer queueId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldQueueId());
+            Integer nbRxPkts = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbRxPkts());
+            Integer size = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldSize());
+            int portQuark = ssb.getQuarkAbsoluteAndAdd(ETH_NICS, String.valueOf(portId));
+            int rxQsQark = ssb.getQuarkRelativeAndAdd(portQuark, RX_Q);
+            int rxQueueQark = ssb.getQuarkRelativeAndAdd(rxQsQark, Objects.requireNonNull(queueId).toString());
+            updateCounts(ssb, rxQueueQark, Objects.requireNonNull(nbRxPkts), Objects.requireNonNull(size), ts);
+
+        } else if (eventName.equals(DpdkEthdevEventLayout.eventProfileEthdevTxBurst())) { // **
+            Integer queueId = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldQueueId());
+            Integer nbTxPkts = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldNbTxPkts());
+            Integer size = event.getContent().getFieldValue(Integer.class, DpdkEthdevEventLayout.fieldSize());
+            int portQuark = ssb.getQuarkAbsoluteAndAdd(ETH_NICS, String.valueOf(portId));
+            int txQsQark = ssb.getQuarkRelativeAndAdd(portQuark, TX_Q);
+            int txQueueQark = ssb.getQuarkRelativeAndAdd(txQsQark, Objects.requireNonNull(queueId).toString());
+            updateCounts(ssb, txQueueQark, Objects.requireNonNull(nbTxPkts), Objects.requireNonNull(size), ts);
+        }
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevEventLayout.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevEventLayout.java
@@ -1,0 +1,117 @@
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+
+/**
+ * The event layout class to specify event names and their fields
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevEventLayout {
+
+    /* Event names */
+    private static final String ETH_DEV_CONFIGURE = "lib.ethdev.configure"; //$NON-NLS-1$
+    private static final String PROFILE_ETH_DEV_TX_BURST = "lib.ethdev.tx.burst.extended"; //$NON-NLS-1$
+    private static final String PROFILE_ETH_DEV_RX_BURST = "lib.ethdev.rx.burst.extended"; //$NON-NLS-1$
+
+    /* Event field names */
+    private static final String PORT_ID = "port_id"; //$NON-NLS-1$
+    private static final String QUEUE_ID = "queue_id"; //$NON-NLS-1$
+    private static final String NB_RX_Q = "nb_rx_q";//$NON-NLS-1$
+    private static final String NB_TX_Q = "nb_tx_q";//$NON-NLS-1$
+    private static final String NB_RX = "nb_rx"; //$NON-NLS-1$
+    private static final String SIZE = "size"; //$NON-NLS-1$
+    private static final String NB_TX = "nb_tx"; //$NON-NLS-1$
+    private static final String RC = "rc"; //$NON-NLS-1$
+
+
+    // ------------------------------------------------------------------------
+    // Event names
+    // ------------------------------------------------------------------------
+
+    /**
+     * This event is triggered when the app finishes configuring the Ethernet device.
+     *
+     * @return The event name
+     */
+    public static String eventEthdevConfigure() {
+        return ETH_DEV_CONFIGURE;
+    }
+
+    /**
+     * This event is generated when a burst of packets is received
+     *
+     * @return The event name
+     */
+    public static String eventProfileEthdevRxBurst() {
+        return PROFILE_ETH_DEV_RX_BURST;
+    }
+
+    /**
+     * This event is generated when a burst of packets is sent
+     *
+     * @return The event name
+     */
+    public static String eventProfileEthdevTxBurst() {
+        return PROFILE_ETH_DEV_TX_BURST;
+    }
+
+    // ------------------------------------------------------------------------
+    // Event field names
+    // ------------------------------------------------------------------------
+
+    /**
+     * @return Number identifying a NIC port
+     */
+    public static String fieldPortId() {
+        return PORT_ID;
+    }
+
+    /**
+     * @return Number identifying a queue that is associated to a NIC port
+     */
+    public static String fieldQueueId() {
+        return QUEUE_ID;
+    }
+
+    /**
+     * @return The number of configured Rx queues
+     */
+    public static String fieldNbRxQ() {
+        return NB_RX_Q;
+    }
+
+    /**
+     * @return The number of configured Tx queues
+     */
+    public static String fieldNbTxQ() {
+        return NB_TX_Q;
+    }
+
+    /**
+     * @return The number of packets received
+     */
+    public static String fieldNbRxPkts() {
+        return NB_RX;
+    }
+
+    /**
+     * @return The number of packets received
+     */
+    public static String fieldNbTxPkts() {
+        return NB_TX;
+    }
+
+    /**
+     * @return The number of packets received
+     */
+    public static String fieldSize() {
+        return SIZE;
+    }
+
+    /**
+     * @return Code indicating whether the operation was successfull or not
+     */
+    public static String fieldRc() {
+        return RC;
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevStateProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEthdevStateProvider.java
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.AbstractDpdkStateProvider;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * state provider for the {@link DpdkEthdevAnalysisModule} analysis
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEthdevStateProvider extends AbstractDpdkStateProvider {
+
+    private static final int VERSION = 1;
+
+    /** Map events needed for this analysis with their handler functions */
+    private @Nullable Map<String, IDpdkEventHandler> fEventNames;
+
+    /**
+     * Constructor
+     *
+     * @param trace
+     *            trace
+     * @param id
+     *            id
+     */
+    protected DpdkEthdevStateProvider(ITmfTrace trace, String id) {
+        super(trace, id);
+    }
+
+    /**
+     * Get the version of this state provider
+     */
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    /**
+     * Get a new instance
+     */
+    @Override
+    public ITmfStateProvider getNewInstance() {
+        return new DpdkEthdevStateProvider(this.getTrace(), DpdkEthdevAnalysisModule.ID);
+    }
+
+
+
+    @Override
+    protected @Nullable IDpdkEventHandler getEventHandler(String eventName) {
+        if (fEventNames == null) {
+            ImmutableMap.Builder<String, IDpdkEventHandler> builder = ImmutableMap.builder();
+            IDpdkEventHandler ethdevEventHandler = new DpdkEthdevEventHandler();
+            builder.put(DpdkEthdevEventLayout.eventEthdevConfigure(), ethdevEventHandler);
+            //Events generated when using the custom profling library
+            builder.put(DpdkEthdevEventLayout.eventProfileEthdevTxBurst(), ethdevEventHandler);
+            builder.put(DpdkEthdevEventLayout.eventProfileEthdevRxBurst(), ethdevEventHandler);
+            fEventNames = builder.build();
+        }
+        if (fEventNames != null) {
+            return fEventNames.get(eventName);
+        }
+        return null;
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputBpsDataProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputBpsDataProvider.java
@@ -1,0 +1,374 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
+import org.eclipse.tracecompass.tmf.core.model.CommonStatusMessage;
+import org.eclipse.tracecompass.tmf.core.model.IOutputStyleProvider;
+import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
+import org.eclipse.tracecompass.tmf.core.model.OutputStyleModel;
+import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
+import org.eclipse.tracecompass.tmf.core.model.YModel;
+import org.eclipse.tracecompass.tmf.core.model.filters.SelectionTimeQueryFilter;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.AbstractTreeCommonXDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.IYModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfXYAxisDescription;
+import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
+import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+/**
+ * This data provider will return a XY model showing showing traffic throughput
+ * per queue, in bit per second (bps)
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherThroughputBpsDataProvider extends AbstractTreeCommonXDataProvider<DpdkEthdevAnalysisModule, TmfTreeDataModel>
+        implements IOutputStyleProvider {
+
+    /**
+     * Extension point ID.
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.bps.dataprovider"; //$NON-NLS-1$
+
+    /**
+     * Title used to create XY models for the
+     * {@link DpdkEtherThroughputBpsDataProvider}.
+     */
+    protected static final String PROVIDER_TITLE = Objects.requireNonNull("Dpdk Ethernet Device Throughput BPS"); //$NON-NLS-1$
+
+    private static final String BASE_STYLE = "base"; //$NON-NLS-1$
+    private static final Map<String, OutputElementStyle> STATE_MAP;
+    private static final String BINARY_SPEED_UNIT = "b/s"; //$NON-NLS-1$
+    private static final String NICS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_NICs);
+    private static final String RX_QS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_NIC_RX);
+    private static final String TX_QS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_NIC_TX);
+    private static final List<Pair<String, String>> COLOR_LIST = IODataPalette.getColors();
+    private static final TmfXYAxisDescription Y_AXIS_DESCRIPTION = new TmfXYAxisDescription(Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_YAxis), BINARY_SPEED_UNIT, DataType.NUMBER);
+    private static final List<String> SUPPORTED_STYLES = ImmutableList.of(
+            StyleProperties.SeriesStyle.SOLID,
+            StyleProperties.SeriesStyle.DASH,
+            StyleProperties.SeriesStyle.DOT,
+            StyleProperties.SeriesStyle.DASHDOT,
+            StyleProperties.SeriesStyle.DASHDOTDOT);
+
+    static {
+        // Create the base style
+        ImmutableMap.Builder<String, OutputElementStyle> builder = new ImmutableMap.Builder<>();
+        builder.put(BASE_STYLE, new OutputElementStyle(null, ImmutableMap.of(StyleProperties.SERIES_TYPE, StyleProperties.SeriesType.AREA, StyleProperties.WIDTH, 1.0f)));
+        STATE_MAP = builder.build();
+    }
+
+    /**
+     * Class for encapsulating all the values required to build a series.
+     */
+    private static final class NicQueueBuilder {
+
+        private static final double SECONDS_PER_NANOSECOND = 1E-9;
+        private final long fId;
+        /**
+         * This series' represent the number of packets received or transmitted
+         * by a NIC port queue
+         */
+        public final int fQueueQuark;
+        private final String fName;
+        private final double[] fValues;
+        private double fPrevCount;
+
+        /**
+         * Constructor
+         *
+         * @param id
+         *            the series Id
+         * @param nicQueueQuark
+         *            queue's quark
+         * @param name
+         *            name of this series
+         * @param length
+         *            desired length of the series
+         */
+        private NicQueueBuilder(long id, int nicQueueQuark, String name, int length) {
+            fId = id;
+            fQueueQuark = nicQueueQuark;
+            fName = name;
+            fValues = new double[length];
+        }
+
+        private void setPrevCount(double prevCount) {
+            fPrevCount = prevCount;
+        }
+
+        /**
+         * Update the value for the counter at the desired index.
+         *
+         * @param pos
+         *            index to update
+         * @param newCount
+         *            new number of read / written sectors
+         * @param deltaT
+         *            time difference to the previous value for interpolation
+         */
+        private void updateValue(int pos, double newCount, long deltaT) {
+            /**
+             * Linear interpolation to compute the queue throughput between time
+             * and the previous time, from the number of packets received or
+             * sent at each time.
+             */
+            fValues[pos] = (newCount - fPrevCount) * 8 / (SECONDS_PER_NANOSECOND * deltaT);
+            fPrevCount = newCount;
+        }
+
+        private IYModel build() {
+            return new YModel(fId, fName, fValues, Y_AXIS_DESCRIPTION);
+        }
+    }
+
+    /**
+     * Create an instance of {@link DpdkEtherThroughputBpsDataProvider}. Returns
+     * a null instance if the analysis module is not found.
+     *
+     * @param trace
+     *            A trace on which we are interested to fetch a model
+     * @return A {@link DpdkEtherThroughputBpsDataProvider} instance. If
+     *         analysis module is not found, it returns null
+     */
+    public static @Nullable DpdkEtherThroughputBpsDataProvider create(ITmfTrace trace) {
+        DpdkEthdevAnalysisModule module = TmfTraceUtils.getAnalysisModuleOfClass(trace, DpdkEthdevAnalysisModule.class, DpdkEthdevAnalysisModule.ID);
+        if (module != null) {
+            module.schedule();
+            return new DpdkEtherThroughputBpsDataProvider(trace, module);
+        }
+        return null;
+    }
+
+    /**
+     * Constructor
+     */
+    private DpdkEtherThroughputBpsDataProvider(ITmfTrace trace, DpdkEthdevAnalysisModule module) {
+        super(trace, module);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * Get parts of the XY tree that are related to the RX and TX queues
+     *
+     * @param ss
+     *            state system
+     * @param qsQuark
+     *            quark of the queues list
+     * @param nicName
+     *            name of the NIC to which the queues belong
+     * @param nicId
+     *            id of the related NIC
+     * @return a list of {@link TmfTreeDataModel}
+     */
+    List<TmfTreeDataModel> getQueuesTree(ITmfStateSystem ss, int qsQuark, String nicName, long nicId) {
+        int i = 0;
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        boolean isRxQueue = true;
+
+        try {
+            if (ss.getAttributeName(qsQuark).equals(Attributes.TX_Q)) {
+                isRxQueue = false;
+            }
+
+            long qsId = getId(qsQuark);
+            nodes.add(new TmfTreeDataModel(qsId, nicId, Collections.singletonList(isRxQueue ? RX_QS_LABEL : TX_QS_LABEL), false, null));
+            for (Integer queueQuark : ss.getSubAttributes(qsQuark, false)) {
+                String queueName = ss.getAttributeName(queueQuark);
+                long queueId = getId(queueQuark);
+
+                // get colors for this queue corresponding to their types (reception or transmission)
+                Pair<String, String> pair = COLOR_LIST.get(i % COLOR_LIST.size());
+                String seriesStyle = SUPPORTED_STYLES.get((i / COLOR_LIST.size()) % SUPPORTED_STYLES.size());
+
+                if (queueQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                    nodes.add(new TmfTreeDataModel(queueId, qsId, Collections.singletonList(queueName), true,
+                            new OutputElementStyle(BASE_STYLE, ImmutableMap.of(
+                                    StyleProperties.COLOR, isRxQueue ? pair.getFirst() : pair.getSecond(),
+                                    StyleProperties.SERIES_STYLE, seriesStyle,
+                                    StyleProperties.STYLE_NAME,
+                                    nicName + '/' + RX_QS_LABEL + '/' + queueName))));
+                }
+
+                i++;
+            }
+        } catch (IndexOutOfBoundsException e) {
+            Activator.getInstance().logWarning("A DPDK event (" + DpdkEthdevEventLayout.eventEthdevConfigure() + ") is missing"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return nodes;
+    }
+
+    @Override
+    protected TmfTreeModel<TmfTreeDataModel> getTree(ITmfStateSystem ss, Map<String, Object> parameters, @Nullable IProgressMonitor monitor) {
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        long rootId = getId(ITmfStateSystem.ROOT_ATTRIBUTE);
+        nodes.add(new TmfTreeDataModel(rootId, -1, Collections.singletonList(Objects.requireNonNull(getTrace().getName())), false, null));
+
+        try {
+            int nicsQuark = ss.getQuarkAbsolute(Attributes.NICS);
+            long nicsId = getId(nicsQuark);
+            nodes.add(new TmfTreeDataModel(nicsId, rootId, Collections.singletonList(NICS_LABEL), false, null));
+
+            for (Integer nicQuark : ss.getQuarks(Attributes.NICS, "*")) { //$NON-NLS-1$
+                String nicName = ss.getAttributeName(nicQuark);
+                long nicId = getId(nicQuark);
+                nodes.add(new TmfTreeDataModel(nicId, nicsId, Collections.singletonList(nicName), false, null));
+
+                int rxQsQuark = ss.optQuarkRelative(nicQuark, Attributes.RX_Q);
+                int txQsQuark = ss.optQuarkRelative(nicQuark, Attributes.TX_Q);
+                if (rxQsQuark == ITmfStateSystem.INVALID_ATTRIBUTE && txQsQuark == ITmfStateSystem.INVALID_ATTRIBUTE) {
+                    continue;
+                }
+
+                nodes.addAll(getQueuesTree(ss, rxQsQuark, nicName, nicId));
+                nodes.addAll(getQueuesTree(ss, txQsQuark, nicName, nicId));
+
+            }
+        } catch (AttributeNotFoundException e) {
+            Activator.getInstance().logError("Error getting the root attribute of " + Attributes.NICS); //$NON-NLS-1$
+        }
+        return new TmfTreeModel<>(Collections.emptyList(), nodes);
+    }
+
+    /**
+     * Extract a packets counts
+     *
+     * @param queueQuark
+     *            NIC queue quark
+     * @param states
+     *            ITmfStateInterval values
+     * @return number of packets received or sent from a queue
+     */
+    public static double extractCount(int queueQuark, ITmfStateSystem ss, List<ITmfStateInterval> states) {
+        double count = 0.0;
+        try {
+            int metricQuark = ss.getQuarkRelative(queueQuark, Attributes.PKT_SIZE);
+            Object stateValue = states.get(metricQuark).getValue();
+            count = (stateValue instanceof Number) ? ((Number) stateValue).doubleValue() : 0.0;
+        } catch (AttributeNotFoundException e) {
+        }
+        return count;
+    }
+
+    @Override
+    protected @Nullable Collection<IYModel> getYSeriesModels(ITmfStateSystem ss, Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) throws StateSystemDisposedException {
+        SelectionTimeQueryFilter filter = FetchParametersUtils.createSelectionTimeQuery(fetchParameters);
+        if (filter == null) {
+            return null;
+        }
+        long[] xValues = filter.getTimesRequested();
+        List<NicQueueBuilder> builders = initBuilders(ss, filter);
+        if (builders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        long currentEnd = ss.getCurrentEndTime();
+        long prevTime = filter.getStart();
+        if (prevTime >= ss.getStartTime() && prevTime <= currentEnd) {
+            // reuse the results from the full query
+            List<ITmfStateInterval> states = ss.queryFullState(prevTime);
+
+            for (NicQueueBuilder entry : builders) {
+                entry.setPrevCount(extractCount(entry.fQueueQuark, ss, states));
+            }
+        }
+
+        for (int i = 1; i < xValues.length; i++) {
+            if (monitor != null && monitor.isCanceled()) {
+                return null;
+            }
+            long time = xValues[i];
+            if (time > currentEnd) {
+                break;
+            } else if (time >= ss.getStartTime()) {
+                List<ITmfStateInterval> states = ss.queryFullState(time);
+
+                for (NicQueueBuilder entry : builders) {
+                    double count = extractCount(entry.fQueueQuark, ss, states);
+                    entry.updateValue(i, count, time - prevTime);
+                }
+            }
+            prevTime = time;
+        }
+        return ImmutableList.copyOf(Iterables.transform(builders, NicQueueBuilder::build));
+    }
+
+    private List<NicQueueBuilder> initBuilders(ITmfStateSystem ss, SelectionTimeQueryFilter filter) {
+        int length = filter.getTimesRequested().length;
+        List<NicQueueBuilder> builders = new ArrayList<>();
+
+        for (Entry<Long, Integer> entry : getSelectedEntries(filter).entrySet()) {
+            long id = Objects.requireNonNull(entry.getKey());
+            int quark = Objects.requireNonNull(entry.getValue());
+
+            if ((quark == ITmfStateSystem.ROOT_ATTRIBUTE) ||
+                    (ss.getParentAttributeQuark(quark) == ITmfStateSystem.ROOT_ATTRIBUTE)) {
+                continue;
+            }
+
+            int parentQuark = ss.getParentAttributeQuark(quark);
+            if (parentQuark != ITmfStateSystem.INVALID_ATTRIBUTE &&
+                    ((ss.getAttributeName(parentQuark).equals(Attributes.RX_Q) ||
+                            ss.getAttributeName(parentQuark).equals(Attributes.TX_Q)))) {
+                int nicQuark = ss.getParentAttributeQuark(parentQuark);
+                String name = getTrace().getName() + '/' + ss.getAttributeName(nicQuark) + '/' + ss.getAttributeName(parentQuark) + '/' + ss.getAttributeName(quark);
+                builders.add(new NicQueueBuilder(id, quark, name, length));
+            }
+
+        }
+        return builders;
+    }
+
+    @Override
+    protected boolean isCacheable() {
+        return true;
+    }
+
+    @Override
+    protected String getTitle() {
+        return PROVIDER_TITLE;
+    }
+
+    @Override
+    public TmfModelResponse<OutputStyleModel> fetchStyle(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
+        return new TmfModelResponse<>(new OutputStyleModel(STATE_MAP), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputBpsDataProviderFactory.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputBpsDataProviderFactory.java
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.ITmfTreeXYDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfTreeXYCompositeDataProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+/**
+ * Factory to create instances of the {@link DpdkEtherThroughputBpsDataProvider}.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherThroughputBpsDataProviderFactory implements IDataProviderFactory {
+    private static final Predicate<? super ITmfTrace> PREDICATE = t -> TmfTraceUtils.getAnalysisModuleOfClass(t, DpdkEthdevAnalysisModule.class, DpdkEthdevAnalysisModule.ID) != null;
+    private static final IDataProviderDescriptor DESCRIPTOR = new DataProviderDescriptor.Builder()
+            .setId( DpdkEtherThroughputBpsDataProvider.ID)
+            .setName("Dpdk Ethernet Throughput BPS") //$NON-NLS-1$
+            .setDescription("XY chart illustrating the throughput of DPDK Ethernet NIC ports in terms of bits per seconds") //$NON-NLS-1$
+            .setProviderType(ProviderType.TREE_TIME_XY)
+            .build();
+
+    @Override
+    public @Nullable ITmfTreeXYDataProvider<? extends ITmfTreeDataModel> createProvider(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        if (traces.size() == 1) {
+            return DpdkEtherThroughputBpsDataProvider.create(trace);
+        }
+        return TmfTreeXYCompositeDataProvider.create(traces, DpdkEtherThroughputBpsDataProvider.PROVIDER_TITLE, DpdkEtherThroughputBpsDataProvider.ID);
+    }
+
+    @Override
+    public Collection<IDataProviderDescriptor> getDescriptors(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        return Iterables.any(traces, PREDICATE) ? Collections.singletonList(DESCRIPTOR) : Collections.emptyList();
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputPpsDataProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputPpsDataProvider.java
@@ -1,0 +1,376 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
+import org.eclipse.tracecompass.tmf.core.model.CommonStatusMessage;
+import org.eclipse.tracecompass.tmf.core.model.IOutputStyleProvider;
+import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
+import org.eclipse.tracecompass.tmf.core.model.OutputStyleModel;
+import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
+import org.eclipse.tracecompass.tmf.core.model.YModel;
+import org.eclipse.tracecompass.tmf.core.model.filters.SelectionTimeQueryFilter;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.AbstractTreeCommonXDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.IYModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfXYAxisDescription;
+import org.eclipse.tracecompass.tmf.core.response.ITmfResponse;
+import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+/**
+ * This data provider returns an XY model representing the throughput of
+ * transmitted or received network traffic in bits per second (bps). This model
+ * can be used to generate time-series charts that visualize the network's
+ * bandwidth usage over time.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherThroughputPpsDataProvider extends AbstractTreeCommonXDataProvider<DpdkEthdevAnalysisModule, TmfTreeDataModel>
+        implements IOutputStyleProvider {
+
+    /**
+     * Extension point ID.
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.pps.dataprovider"; //$NON-NLS-1$
+
+    /**
+     * Title used to create XY models for the
+     * {@link DpdkEtherThroughputPpsDataProvider}.
+     */
+    protected static final String PROVIDER_TITLE = Objects.requireNonNull("Dpdk Ethernet Device Throughput PPS"); //$NON-NLS-1$
+
+    private static final String BASE_STYLE = "base"; //$NON-NLS-1$
+    private static final Map<String, OutputElementStyle> STATE_MAP;
+    private static final String BINARY_SPEED_UNIT = "/s"; //$NON-NLS-1$
+    private static final String NICS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_NICs);
+    private static final String RX_QS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_NIC_RX);
+    private static final String TX_QS_LABEL = Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_NIC_TX);
+    private static final List<Pair<String, String>> COLOR_LIST = IODataPalette.getColors();
+    private static final TmfXYAxisDescription Y_AXIS_DESCRIPTION = new TmfXYAxisDescription(Objects.requireNonNull(Messages.DpdkEthdev_ThroughputDataProvider_YAxis), BINARY_SPEED_UNIT, DataType.NUMBER);
+    private static final List<String> SUPPORTED_STYLES = ImmutableList.of(
+            StyleProperties.SeriesStyle.SOLID,
+            StyleProperties.SeriesStyle.DASH,
+            StyleProperties.SeriesStyle.DOT,
+            StyleProperties.SeriesStyle.DASHDOT,
+            StyleProperties.SeriesStyle.DASHDOTDOT);
+
+    static {
+        // Create the base style
+        ImmutableMap.Builder<String, OutputElementStyle> builder = new ImmutableMap.Builder<>();
+        builder.put(BASE_STYLE, new OutputElementStyle(null, ImmutableMap.of(StyleProperties.SERIES_TYPE, StyleProperties.SeriesType.AREA, StyleProperties.WIDTH, 1.0f)));
+        STATE_MAP = builder.build();
+    }
+
+    /**
+     * Class for encapsulating all the values required to build a series.
+     */
+    private static final class NicQueueBuilder {
+
+        private static final double SECONDS_PER_NANOSECOND = 1E-9;
+        private final long fId;
+        /**
+         * This series' represent the number of packets received or transmitted
+         * by a NIC port queue
+         */
+        public final int fQueueQuark;
+        private final String fName;
+        private final double[] fValues;
+        private double fPrevCount;
+
+        /**
+         * Constructor
+         *
+         * @param id
+         *            the series Id
+         * @param nicQueueQuark
+         *            queue's quark
+         * @param name
+         *            name of this series
+         * @param length
+         *            desired length of the series
+         */
+        private NicQueueBuilder(long id, int nicQueueQuark, String name, int length) {
+            fId = id;
+            fQueueQuark = nicQueueQuark;
+            fName = name;
+            fValues = new double[length];
+        }
+
+        private void setPrevCount(double prevCount) {
+            fPrevCount = prevCount;
+        }
+
+        /**
+         * Update the value for the counter at the desired index.
+         *
+         * @param pos
+         *            index to update
+         * @param newCount
+         *            new number of read / written sectors
+         * @param deltaT
+         *            time difference to the previous value for interpolation
+         */
+        private void updateValue(int pos, double newCount, long deltaT) {
+            /**
+             * Linear interpolation to compute the queue throughput between time
+             * and the previous time, from the number of packets received or
+             * sent at each time.
+             */
+            fValues[pos] = (newCount - fPrevCount) / (SECONDS_PER_NANOSECOND * deltaT);
+            fPrevCount = newCount;
+        }
+
+        private IYModel build() {
+            return new YModel(fId, fName, fValues, Y_AXIS_DESCRIPTION);
+        }
+    }
+
+    /**
+     * Create an instance of {@link DpdkEtherThroughputPpsDataProvider}. Returns
+     * a null instance if the analysis module is not found.
+     *
+     * @param trace
+     *            A trace on which we are interested to fetch a model
+     * @return A {@link DpdkEtherThroughputPpsDataProvider} instance. If
+     *         analysis module is not found, it returns null
+     */
+    public static @Nullable DpdkEtherThroughputPpsDataProvider create(ITmfTrace trace) {
+        DpdkEthdevAnalysisModule module = TmfTraceUtils.getAnalysisModuleOfClass(trace, DpdkEthdevAnalysisModule.class, DpdkEthdevAnalysisModule.ID);
+        if (module != null) {
+            module.schedule();
+            return new DpdkEtherThroughputPpsDataProvider(trace, module);
+        }
+        return null;
+    }
+
+    /**
+     * Constructor
+     */
+    private DpdkEtherThroughputPpsDataProvider(ITmfTrace trace, DpdkEthdevAnalysisModule module) {
+        super(trace, module);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * Get parts of the XY tree that are related to Rx and Tx queues
+     *
+     * @param ss
+     *            State System
+     * @param qsQuark
+     *            Queues list quark
+     * @param nicName
+     *            Name of the NIC to which the queues belong
+     * @param nicId
+     *            Id of the related NIC
+     * @return a list of TmfTreeDataModel
+     */
+    List<TmfTreeDataModel> getQueuesTree(ITmfStateSystem ss, int qsQuark, String nicName, long nicId) {
+        int i = 0;
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        boolean isRxQueue = true;
+
+        try {
+            if (ss.getAttributeName(qsQuark).equals(Attributes.TX_Q)) {
+                isRxQueue = false;
+            }
+
+            long qsId = getId(qsQuark);
+            nodes.add(new TmfTreeDataModel(qsId, nicId, Collections.singletonList(isRxQueue ? RX_QS_LABEL : TX_QS_LABEL), false, null));
+            for (Integer queueQuark : ss.getSubAttributes(qsQuark, false)) {
+                String queueName = ss.getAttributeName(queueQuark);
+                long queueId = getId(queueQuark);
+
+                // Get receive or send colors for this queue
+                Pair<String, String> pair = COLOR_LIST.get(i % COLOR_LIST.size());
+                String seriesStyle = SUPPORTED_STYLES.get((i / COLOR_LIST.size()) % SUPPORTED_STYLES.size());
+
+                if (queueQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                    nodes.add(new TmfTreeDataModel(queueId, qsId, Collections.singletonList(queueName), true,
+                            new OutputElementStyle(BASE_STYLE, ImmutableMap.of(
+                                    StyleProperties.COLOR, isRxQueue ? pair.getFirst() : pair.getSecond(),
+                                    StyleProperties.SERIES_STYLE, seriesStyle,
+                                    StyleProperties.STYLE_NAME,
+                                    nicName + '/' + RX_QS_LABEL + '/' + queueName))));
+                }
+
+                i++;
+            }
+        } catch (IndexOutOfBoundsException e) {
+            Activator.getInstance().logWarning("A DPDK event (" + DpdkEthdevEventLayout.eventEthdevConfigure() + ") is missing"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        return nodes;
+    }
+
+    @Override
+    protected TmfTreeModel<TmfTreeDataModel> getTree(ITmfStateSystem ss, Map<String, Object> parameters, @Nullable IProgressMonitor monitor) {
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        long rootId = getId(ITmfStateSystem.ROOT_ATTRIBUTE);
+        nodes.add(new TmfTreeDataModel(rootId, -1, Collections.singletonList(Objects.requireNonNull(getTrace().getName())), false, null));
+
+        try {
+            int nicsQuark = ss.getQuarkAbsolute(Attributes.NICS);
+            long nicsId = getId(nicsQuark);
+            nodes.add(new TmfTreeDataModel(nicsId, rootId, Collections.singletonList(NICS_LABEL), false, null));
+
+            for (Integer nicQuark : ss.getQuarks(Attributes.NICS, "*")) { //$NON-NLS-1$
+                String nicName = ss.getAttributeName(nicQuark);
+                long nicId = getId(nicQuark);
+                nodes.add(new TmfTreeDataModel(nicId, nicsId, Collections.singletonList(nicName), false, null));
+
+                int rxQsQuark = ss.optQuarkRelative(nicQuark, Attributes.RX_Q);
+                int txQsQuark = ss.optQuarkRelative(nicQuark, Attributes.TX_Q);
+                if (rxQsQuark == ITmfStateSystem.INVALID_ATTRIBUTE && txQsQuark == ITmfStateSystem.INVALID_ATTRIBUTE) {
+                    continue;
+                }
+
+                nodes.addAll(getQueuesTree(ss, rxQsQuark, nicName, nicId));
+                nodes.addAll(getQueuesTree(ss, txQsQuark, nicName, nicId));
+
+            }
+        } catch (AttributeNotFoundException e) {
+            Activator.getInstance().logError("Error getting the root attribute of " + Attributes.NICS); //$NON-NLS-1$
+        }
+        return new TmfTreeModel<>(Collections.emptyList(), nodes);
+    }
+
+    /**
+     * Extract a packets counts
+     *
+     * @param queueQuark
+     *            NIC queue quark
+     * @param states
+     *            ITmfStateInterval state values
+     * @return number of packets received or sent from the RX/TX queue
+     */
+    public static double extractCount(int queueQuark, ITmfStateSystem ss, List<ITmfStateInterval> states) {
+        double count = 0.0;
+        try {
+            int metricQuark = ss.getQuarkRelative(queueQuark, Attributes.PKT_COUNT);
+            Object stateValue = states.get(metricQuark).getValue();
+            count = (stateValue instanceof Number) ? ((Number) stateValue).doubleValue() : 0.0;
+        } catch (AttributeNotFoundException e) {
+        }
+        return count;
+    }
+
+    @Override
+    protected @Nullable Collection<IYModel> getYSeriesModels(ITmfStateSystem ss, Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) throws StateSystemDisposedException {
+        SelectionTimeQueryFilter filter = FetchParametersUtils.createSelectionTimeQuery(fetchParameters);
+        if (filter == null) {
+            return null;
+        }
+        long[] xValues = filter.getTimesRequested();
+        List<NicQueueBuilder> builders = initBuilders(ss, filter);
+        if (builders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        long currentEnd = ss.getCurrentEndTime();
+        long prevTime = filter.getStart();
+        if (prevTime >= ss.getStartTime() && prevTime <= currentEnd) {
+            // reuse the results from the full query
+            List<ITmfStateInterval> states = ss.queryFullState(prevTime);
+
+            for (NicQueueBuilder entry : builders) {
+                entry.setPrevCount(extractCount(entry.fQueueQuark, ss, states));
+            }
+        }
+
+        for (int i = 1; i < xValues.length; i++) {
+            if (monitor != null && monitor.isCanceled()) {
+                return null;
+            }
+            long time = xValues[i];
+            if (time > currentEnd) {
+                break;
+            } else if (time >= ss.getStartTime()) {
+                List<ITmfStateInterval> states = ss.queryFullState(time);
+
+                for (NicQueueBuilder entry : builders) {
+                    double count = extractCount(entry.fQueueQuark, ss, states);
+                    entry.updateValue(i, count, time - prevTime);
+                }
+            }
+            prevTime = time;
+        }
+        return ImmutableList.copyOf(Iterables.transform(builders, NicQueueBuilder::build));
+    }
+
+    private List<NicQueueBuilder> initBuilders(ITmfStateSystem ss, SelectionTimeQueryFilter filter) {
+        int length = filter.getTimesRequested().length;
+        List<NicQueueBuilder> builders = new ArrayList<>();
+
+        for (Entry<Long, Integer> entry : getSelectedEntries(filter).entrySet()) {
+            long id = Objects.requireNonNull(entry.getKey());
+            int quark = Objects.requireNonNull(entry.getValue());
+
+            if ((quark == ITmfStateSystem.ROOT_ATTRIBUTE) ||
+                    (ss.getParentAttributeQuark(quark) == ITmfStateSystem.ROOT_ATTRIBUTE)) {
+                continue;
+            }
+
+            int parentQuark = ss.getParentAttributeQuark(quark);
+            if (parentQuark != ITmfStateSystem.INVALID_ATTRIBUTE &&
+                    ((ss.getAttributeName(parentQuark).equals(Attributes.RX_Q) ||
+                            ss.getAttributeName(parentQuark).equals(Attributes.TX_Q)))) {
+                int nicQuark = ss.getParentAttributeQuark(parentQuark);
+                String name = getTrace().getName() + '/' + ss.getAttributeName(nicQuark) + '/' + ss.getAttributeName(parentQuark) + '/' + ss.getAttributeName(quark);
+                builders.add(new NicQueueBuilder(id, quark, name, length));
+            }
+
+        }
+        return builders;
+    }
+
+    @Override
+    protected boolean isCacheable() {
+        return true;
+    }
+
+    @Override
+    protected String getTitle() {
+        return PROVIDER_TITLE;
+    }
+
+    @Override
+    public TmfModelResponse<OutputStyleModel> fetchStyle(Map<String, Object> fetchParameters, @Nullable IProgressMonitor monitor) {
+        return new TmfModelResponse<>(new OutputStyleModel(STATE_MAP), ITmfResponse.Status.COMPLETED, CommonStatusMessage.COMPLETED);
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputPpsDataProviderFactory.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/DpdkEtherThroughputPpsDataProviderFactory.java
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.ITmfTreeXYDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfTreeXYCompositeDataProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+/**
+ * Factory to create instances of the
+ * {@link DpdkEtherThroughputPpsDataProvider}.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkEtherThroughputPpsDataProviderFactory implements IDataProviderFactory {
+    private static final Predicate<? super ITmfTrace> PREDICATE = t -> TmfTraceUtils.getAnalysisModuleOfClass(t, DpdkEthdevAnalysisModule.class, DpdkEthdevAnalysisModule.ID) != null;
+    private static final IDataProviderDescriptor DESCRIPTOR = new DataProviderDescriptor.Builder()
+            .setId( DpdkEtherThroughputPpsDataProvider.ID)
+            .setName("Dpdk Ethernet Throughput PPS") //$NON-NLS-1$
+            .setDescription("XY chart illustrating the throughput of DPDK Ethernet NIC ports in terms of PPS") //$NON-NLS-1$
+            .setProviderType(ProviderType.TREE_TIME_XY)
+            .build();
+
+    @Override
+    public @Nullable ITmfTreeXYDataProvider<? extends ITmfTreeDataModel> createProvider(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        if (traces.size() == 1) {
+            return DpdkEtherThroughputPpsDataProvider.create(trace);
+        }
+        return TmfTreeXYCompositeDataProvider.create(traces, DpdkEtherThroughputPpsDataProvider.PROVIDER_TITLE, DpdkEtherThroughputPpsDataProvider.ID);
+    }
+
+    @Override
+    public Collection<IDataProviderDescriptor> getDescriptors(ITmfTrace trace) {
+        Collection<ITmfTrace> traces = TmfTraceManager.getTraceSet(trace);
+        return Iterables.any(traces, PREDICATE) ? Collections.singletonList(DESCRIPTOR) : Collections.emptyList();
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/IODataPalette.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/IODataPalette.java
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import java.util.List;
+
+import org.eclipse.tracecompass.tmf.core.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A class providing various color pairs for receive/sent data. Receives have a
+ * blueish tint, while the Sends are reddish.
+ *
+ * Those colors are taken from the {@href https://colorbrewer2.org} from
+ * sequential palettes of blues and reds with 6 colors, eliminating the first
+ * paler one
+ *
+ * @author Geneviève Bastien
+ */
+public class IODataPalette {
+
+    private static final List<Pair<String, String>> COLOR_LIST;
+
+    static {
+        ImmutableList.Builder<Pair<String, String>> colorBuilder = new ImmutableList.Builder<>();
+
+        /* First color of each pair is blueish, second reddish */
+        // Middle color: blue sky, peach red
+        colorBuilder.add(new Pair<>(
+                "#6baed6", //$NON-NLS-1$
+                "#fb6a4a")); //$NON-NLS-1$
+        // Darker: blueberry color, dark red going on dark maroon
+        colorBuilder.add(new Pair<>(
+                "#08519c", //$NON-NLS-1$
+                "#a50f15")); //$NON-NLS-1$
+        // Paler: pale grey blue, very pale red orangeish
+        colorBuilder.add(new Pair<>(
+                "#c6dbef", //$NON-NLS-1$
+                "#fcbba1")); //$NON-NLS-1$
+        // Between middle and darker: tahiti sea and red ferrari
+        colorBuilder.add(new Pair<>(
+                "#3182bd", //$NON-NLS-1$
+                "#de2d26")); //$NON-NLS-1$
+        // Between paler and middle: light turquoise, salmon
+        colorBuilder.add(new Pair<>(
+                "#9ecae1", //$NON-NLS-1$
+                "#fc9272")); //$NON-NLS-1$
+
+        COLOR_LIST = colorBuilder.build();
+    }
+
+    private IODataPalette() {
+        // Do nothing
+    }
+
+    /**
+     * Get the list of color pairs for read/write data. For each element in the
+     * list, the first element of the pair is the read color (blueish) and the
+     * second color is the write (reddish).
+     *
+     * The color strings have an hexadecimal format: #xxxxxx
+     *
+     * @return The list of color pairs for read/write
+     */
+    public static List<Pair<String, String>> getColors() {
+        return COLOR_LIST;
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/Messages.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for {@link DpdkEtherThroughputBpsDataProvider}
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings("javadoc")
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.messages"; //$NON-NLS-1$
+    public static @Nullable String DpdkEthdev_ThroughputDataProvider_NICs;
+    public static @Nullable String DpdkEthdev_ThroughputDataProvider_NIC_RX;
+    public static @Nullable String DpdkEthdev_ThroughputDataProvider_NIC_TX;
+    public static @Nullable String DpdkEthdev_ThroughputDataProvider_YAxis;
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/messages.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2018 Ericsson
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+DpdkEthdev_ThroughputDataProvider_NICs=NIC Port
+DpdkEthdev_ThroughputDataProvider_NIC_RX=RX
+DpdkEthdev_ThroughputDataProvider_NIC_TX=TX
+DpdkEthdev_ThroughputDataProvider_YAxis=Throughput

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/package-info.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/ethdev/throughput/analysis/package-info.java
@@ -1,0 +1,13 @@
+/**********************************************************************
+ * Copyright (c) 2023 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+@org.eclipse.jdt.annotation.NonNullByDefault
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis;
+

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
@@ -2,12 +2,20 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension
+         id="org.eclipse.tracecompass.tmf.ui.analysis.TmfAnalysisViewOutput"
          point="org.eclipse.linuxtools.tmf.core.analysis">
       <output
             class="org.eclipse.tracecompass.tmf.ui.analysis.TmfAnalysisViewOutput"
             id="org.eclipse.tracecompass.incubator.dpdk.lcore.view">
          <analysisModuleClass
                class="org.eclipse.tracecompass.incubator.internal.dpdk.core.lcore.analysis.DpdkLogicalCoreAnalysisModule">
+         </analysisModuleClass>
+      </output>
+      <output
+            class="org.eclipse.tracecompass.tmf.ui.analysis.TmfAnalysisViewOutput"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.view">
+         <analysisModuleClass
+               class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEthdevRateAnalysis">
          </analysisModuleClass>
       </output>
    </extension>
@@ -19,9 +27,17 @@
             parentCategory="org.eclipse.linuxtools.tmf.ui.views.category">
       </category>
       <view
+            category="org.eclipse.tracecompass.incubator.internal.dpdk.ui.views.category"
             class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.lcore.LogicalCoreView"
             id="org.eclipse.tracecompass.incubator.dpdk.lcore.view"
             name="Logical Core View"
+            restorable="true">
+      </view>
+      <view
+            category="org.eclipse.tracecompass.incubator.internal.dpdk.ui.views.category"
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.rate.NicQueueRateView"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.view"
+            name="Ethernet Rate View"
             restorable="true">
       </view>
    </extension>

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
@@ -18,6 +18,13 @@
                class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEthdevRateAnalysis">
          </analysisModuleClass>
       </output>
+      <output
+            class="org.eclipse.tracecompass.tmf.ui.analysis.TmfAnalysisViewOutput"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.bps.view">
+         <analysisModuleClass
+               class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.DpdkEthdevAnalysisModule">
+         </analysisModuleClass>
+      </output>
    </extension>
    <extension
          point="org.eclipse.ui.views">
@@ -38,6 +45,13 @@
             class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.rate.NicQueueRateView"
             id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.view"
             name="Ethernet Rate View"
+            restorable="true">
+      </view>
+      <view
+            category="org.eclipse.tracecompass.incubator.internal.dpdk.ui.views.category"
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.throughput.NicQueueThroughputView"
+            id="org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.bps.view"
+            name="Ethernet Throughput View"
             restorable="true">
       </view>
    </extension>

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
@@ -13,6 +13,13 @@
       </output>
       <output
             class="org.eclipse.tracecompass.tmf.ui.analysis.TmfAnalysisViewOutput"
+            id="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin.statistics.view">
+         <analysisModuleClass
+               class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis.DpdkEthdevSpinAnalysisModule">
+         </analysisModuleClass>
+      </output>
+      <output
+            class="org.eclipse.tracecompass.tmf.ui.analysis.TmfAnalysisViewOutput"
             id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.view">
          <analysisModuleClass
                class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEthdevRateAnalysis">
@@ -45,6 +52,13 @@
             class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.rate.NicQueueRateView"
             id="org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.view"
             name="Ethernet Rate View"
+            restorable="true">
+      </view>
+      <view
+            category="org.eclipse.tracecompass.incubator.internal.dpdk.ui.views.category"
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin.ThreadSpinStatisticsView"
+            id="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin.statistics.view"
+            name="Ethernet PMD Effective Busyness"
             restorable="true">
       </view>
       <view

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/Messages.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.rate;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Translatable strings for the {@link NicQueueRateView} View
+ *
+ * @author Houssem Daoud
+ */
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.rate.messages"; //$NON-NLS-1$
+    /** Title of the Disk I/O view */
+    public static @Nullable String EthdevRateView_Title;
+    /** Title of the Disk I/O activity viewer */
+    public static @Nullable String EthdevRateViewer_Title;
+    /** X axis caption */
+    public static @Nullable String EthdevRateViewer_XAxis;
+    /** Disk Name column */
+    public static @Nullable String EthdevRateTreeViewer_NicName;
+    /** Legend Column*/
+    public static @Nullable String EthdevRateTreeViewer_Legend;
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/NicQueueRateView.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/NicQueueRateView.java
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.rate;
+
+import java.util.Comparator;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.rate.analysis.DpdkEtherRateDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.TmfViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.AbstractSelectTreeViewer2;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.ITmfTreeColumnDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfGenericTreeEntry;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfTreeColumnData;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.TmfXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfFilteredXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfXYChartSettings;
+import org.eclipse.tracecompass.tmf.ui.views.xychart.TmfChartView;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This view shows the packet reception and transmission speed per queue
+ *
+ * @author Adel Belkhiri
+ */
+public class NicQueueRateView extends TmfChartView {
+
+    /**
+     * Identifier of this view
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.ethdev.rate.view"; //$NON-NLS-1$
+    private static final double RESOLUTION = 0.2;
+
+    /**
+     * Default constructor
+     */
+    public NicQueueRateView() {
+        super(Messages.EthdevRateView_Title);
+    }
+
+    @Override
+    protected TmfXYChartViewer createChartViewer(Composite parent) {
+        TmfXYChartSettings settings = new TmfXYChartSettings(Messages.EthdevRateViewer_Title, Messages.EthdevRateViewer_XAxis, null, RESOLUTION);
+        return new TmfFilteredXYChartViewer(parent, settings, DpdkEtherRateDataProvider.ID);
+    }
+
+    @Override
+    protected @NonNull TmfViewer createLeftChildViewer(@Nullable Composite parent) {
+        return new AbstractSelectTreeViewer2(parent, 1, DpdkEtherRateDataProvider.ID) {
+            @Override
+            protected ITmfTreeColumnDataProvider getColumnDataProvider() {
+                return () -> {
+                    return ImmutableList.of(
+                            createColumn(Messages.EthdevRateTreeViewer_NicName, Comparator.comparing(TmfGenericTreeEntry::getName)),
+                            new TmfTreeColumnData(Messages.EthdevRateTreeViewer_Legend));
+                };
+            }
+        };
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/messages.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2024 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+EthdevRateView_Title=NIC Rate View
+EthdevRateViewer_Title=NIC Rate View
+EthdevRateViewer_XAxis=Time
+EthdevRateTreeViewer_NicName=NIC Port ID
+EthdevRateTreeViewer_Legend=Legend

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/package-info.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/rate/package-info.java
@@ -1,0 +1,11 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.rate;

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/Messages.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for the {@link ThreadSpinStatisticsViewer} view
+ *
+ * @author Adel Belkhiri
+ */
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin.messages"; //$NON-NLS-1$
+    /** Title of the view */
+    public static @Nullable String EthdevThreadSpinStatsView_Title;
+    /** Title of the viewer */
+    public static @Nullable String EthdevThreadSpinStatsViewer_Title;
+    /** X axis caption */
+    public static @Nullable String EthdevThreadSpinStatsViewer_XAxis;
+    /** Y axis caption */
+    public static @Nullable String EthdevThreadSpinStatsViewer_YAxis;
+    /**  column */
+    public static @Nullable String EthdevThreadSpinStatsTreeViewer_ThreadName;
+    /** Legend Column*/
+    public static @Nullable String EthdevThreadSpinStatsTreeViewer_Legend;
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/ThreadSpinStatisticsView.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/ThreadSpinStatisticsView.java
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin;
+
+import java.util.Comparator;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis.DpdkEtherSpinDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.TmfViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.AbstractSelectTreeViewer2;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.ITmfTreeColumnDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfGenericTreeEntry;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfTreeColumnData;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.TmfXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfXYChartSettings;
+import org.eclipse.tracecompass.tmf.ui.views.xychart.TmfChartView;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Showing the PMD thread real occupancy across the trace duration
+ *
+ * @author Adel Belkhiri
+ */
+public class ThreadSpinStatisticsView extends TmfChartView {
+
+    /**
+     * Identifier of this view
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin.statistics.view"; //$NON-NLS-1$
+    private static final double RESOLUTION = 0.4;
+
+    /**
+     * Default constructor
+     */
+    public ThreadSpinStatisticsView() {
+        super(Messages.EthdevThreadSpinStatsView_Title);
+    }
+
+    @Override
+    protected TmfXYChartViewer createChartViewer(Composite parent) {
+        TmfXYChartSettings settings = new TmfXYChartSettings(Messages.EthdevThreadSpinStatsViewer_Title, Messages.EthdevThreadSpinStatsViewer_XAxis, Messages.EthdevThreadSpinStatsViewer_YAxis, RESOLUTION);
+        return new ThreadSpinStatisticsViewer(parent, settings, DpdkEtherSpinDataProvider.ID);
+    }
+
+    @Override
+    protected @NonNull TmfViewer createLeftChildViewer(@Nullable Composite parent) {
+        return new AbstractSelectTreeViewer2(parent, 1, DpdkEtherSpinDataProvider.ID) {
+            @Override
+            protected ITmfTreeColumnDataProvider getColumnDataProvider() {
+                return () -> {
+                    return ImmutableList.of(
+                            createColumn(Messages.EthdevThreadSpinStatsTreeViewer_ThreadName, Comparator.comparing(TmfGenericTreeEntry::getName)),
+                            new TmfTreeColumnData(Messages.EthdevThreadSpinStatsTreeViewer_Legend));
+                };
+            }
+        };
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/ThreadSpinStatisticsViewer.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/ThreadSpinStatisticsViewer.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
+import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfFilteredXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfXYChartSettings;
+
+/**
+ * Viewer for the {@link ThreadSpinStatisticsView} view
+ *
+ * @author Adel Belkhiri
+ */
+public class ThreadSpinStatisticsViewer extends TmfFilteredXYChartViewer {
+
+    private static final int DEFAULT_SERIES_WIDTH = 1;
+
+    /**
+     * Constructor
+     *
+     * @param parent
+     *            Parent composite
+     * @param settings
+     *            Chart settings
+     * @param providerId
+     *            Data provider ID
+     */
+    public ThreadSpinStatisticsViewer(Composite parent, TmfXYChartSettings settings, String providerId) {
+        super(parent, settings, providerId);
+    }
+
+    @Override
+    public @NonNull OutputElementStyle getSeriesStyle(@NonNull Long seriesId) {
+        return getPresentationProvider().getSeriesStyle(seriesId, StyleProperties.SeriesType.LINE, DEFAULT_SERIES_WIDTH);
+    }
+
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/messages.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+EthdevThreadSpinStatsView_Title=PMD Effective Busyness View
+EthdevThreadSpinStatsViewer_Title=PMD Effective Busyness View
+EthdevThreadSpinStatsViewer_XAxis=Time
+EthdevThreadSpinStatsViewer_YAxis=% BUSY
+EthdevThreadSpinStatsTreeViewer_ThreadName=Threads
+EthdevThreadSpinStatsTreeViewer_Legend=Legend

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/package-info.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/spin/package-info.java
@@ -1,0 +1,11 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin;

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/Messages.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/Messages.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.throughput;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for the {@link NicQueueThroughputView} view
+ *
+ * @author Adel Belkhiri
+ */
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.throughput.messages"; //$NON-NLS-1$
+    /** Title of the Disk I/O view */
+    public static @Nullable String EthdevThroughputView_Title;
+    /** Title of the Disk I/O activity viewer */
+    public static @Nullable String EthdevThroughputViewer_Title;
+    /** X axis caption */
+    public static @Nullable String EthdevThroughputViewer_XAxis;
+    /** Disk Name column */
+    public static @Nullable String EthdevThroughputTreeViewer_NicName;
+    /** Legend Column*/
+    public static @Nullable String EthdevThroughputTreeViewer_Legend;
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/NicQueueThroughputView.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/NicQueueThroughputView.java
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.throughput;
+
+import java.util.Comparator;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis.DpdkEtherThroughputBpsDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.TmfViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.AbstractSelectTreeViewer2;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.ITmfTreeColumnDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfGenericTreeEntry;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfTreeColumnData;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.TmfXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfFilteredXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfXYChartSettings;
+import org.eclipse.tracecompass.tmf.ui.views.xychart.TmfChartView;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This view shows packet reception and transmission throughput per port queue
+ *
+ * @author Adel Belkhiri
+ */
+public class NicQueueThroughputView extends TmfChartView {
+
+    /**
+     * Identifier of this view
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.ethdev.throughput.bps.view"; //$NON-NLS-1$
+    private static final double RESOLUTION = 0.2;
+
+    /**
+     * Default constructor
+     */
+    public NicQueueThroughputView() {
+        super(Messages.EthdevThroughputView_Title);
+    }
+
+    @Override
+    protected TmfXYChartViewer createChartViewer(Composite parent) {
+        TmfXYChartSettings settings = new TmfXYChartSettings(Messages.EthdevThroughputViewer_Title, Messages.EthdevThroughputViewer_XAxis, null, RESOLUTION);
+        return new TmfFilteredXYChartViewer(parent, settings, DpdkEtherThroughputBpsDataProvider.ID);
+    }
+
+    @Override
+    protected @NonNull TmfViewer createLeftChildViewer(@Nullable Composite parent) {
+        return new AbstractSelectTreeViewer2(parent, 1, DpdkEtherThroughputBpsDataProvider.ID) {
+            @Override
+            protected ITmfTreeColumnDataProvider getColumnDataProvider() {
+                return () -> {
+                    return ImmutableList.of(
+                            createColumn(Messages.EthdevThroughputTreeViewer_NicName, Comparator.comparing(TmfGenericTreeEntry::getName)),
+                            new TmfTreeColumnData(Messages.EthdevThroughputTreeViewer_Legend));
+                };
+            }
+        };
+    }
+}

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/messages.properties
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/messages.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2024 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+EthdevThroughputView_Title=NIC Throughput View
+EthdevThroughputViewer_Title=NIC Throughput View
+EthdevThroughputViewer_XAxis=Time
+EthdevThroughputTreeViewer_NicName=NIC Port ID
+EthdevThroughputTreeViewer_Legend=Legend

--- a/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/package-info.java
+++ b/analyses/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/ethdev/throughput/package-info.java
@@ -1,0 +1,11 @@
+/**********************************************************************
+ * Copyright (c) 2024 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.throughput;


### PR DESCRIPTION
This PR introduces 5 performance analyses for DPDK applications implemented using the ethdev library. These analyses provide insights into packet distribution, rate, throughput, and PMD thread busyness, thus helping monitor and optimize application performance.

**New Features:**

1. Packet Rate Analysis:
Computes the packet rate (in pps) for transmitted and received Ethernet traffic on a per-queue basis. It helps monitor the efficiency of traffic processing by calculating the number of packets received or transmitted in a given period.

2. Packet Throughput Analysis:
Analyzes packet throughput (in bps) for transmitted and received Ethernet traffic. This is done on a per-queue basis to evaluate bandwidth usage.

3. Busyness Analysis for PMD Threads:
Estimates how busy PMD threads are by comparing the times they successfully retrieve packets from the NIC queue versus when they are merely spinning without processing any packets. This can be used to evaluate the efficiency of polling operations.

4. Packet Distribution Analysis:
Analyzes the distribution of packets retrieved in a single rte_eth_rx_burst() call, on a per-thread and per-queue basis. This analysis provides insights into packet retrieval patterns, including how evenly or unevenly the workload is distributed across queues.

5. Packet Distribution Statistics:
Computes various statistics related to packet retrieval distribution, including the minimum, maximum, average, and standard deviation for packets retrieved in a single rte_eth_rx_burst() call, which offers more granular visibility into traffic distribution patterns.